### PR TITLE
Fix double-login issue with session middleware and auth flow improvements

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -5,11 +5,19 @@ import { createClient } from "@/lib/supabase/server";
 export async function GET(request: Request) {
   const requestUrl = new URL(request.url);
   const code = requestUrl.searchParams.get("code");
-  const next = requestUrl.searchParams.get("next") ?? "/";
+  const next = requestUrl.searchParams.get("next") ?? "/dashboard";
 
-  if (code) {
-    const supabase = await createClient();
-    await supabase.auth.exchangeCodeForSession(code);
+  if (!code) {
+    return NextResponse.redirect(new URL("/login", requestUrl.origin));
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+  if (error) {
+    const loginUrl = new URL("/login", requestUrl.origin);
+    loginUrl.searchParams.set("error", error.message);
+    return NextResponse.redirect(loginUrl);
   }
 
   return NextResponse.redirect(new URL(next, requestUrl.origin));

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { redirect } from "next/navigation";
 
 import { AppShell } from "@/components/AppShell";
 import type { UserRole } from "@/components/ProfileContext";
@@ -11,22 +12,24 @@ export default async function Layout({ children }: { children: ReactNode }) {
   let initialRole: UserRole | null = null;
 
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  if (session?.user) {
-    const { data } = await supabase
-      .from("profiles")
-      .select("theme, role")
-      .eq("id", session.user.id)
-      .maybeSingle();
+  if (!user) {
+    redirect("/login");
+  }
 
-    if (data?.theme) {
-      initialTheme = data.theme as Theme;
-    }
-    if (data?.role) {
-      initialRole = data.role as UserRole;
-    }
+  const { data } = await supabase
+    .from("profiles")
+    .select("theme, role")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (data?.theme) {
+    initialTheme = data.theme as Theme;
+  }
+  if (data?.role) {
+    initialRole = data.role as UserRole;
   }
 
   return (

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -10,10 +10,10 @@ export const metadata = {
 export default async function LoginPage() {
   const supabase = await createClient();
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  if (session) {
+  if (user) {
     redirect("/dashboard");
   }
 

--- a/components/LoginScreen.tsx
+++ b/components/LoginScreen.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import { Loader2, Mail, Lock, User } from "lucide-react";
 
 import { cn } from "@/components/ui/utils";
+import { primeAccessToken } from "@/lib/api/session";
 import { createClient } from "@/lib/supabase/client";
 
 import styles from "./LoginScreen.module.css";
@@ -80,14 +81,14 @@ export function LoginScreen({ redirectTo = "/dashboard" }: LoginScreenProps) {
         }
 
         if (isSignup) {
-          const { error: signUpError } = await supabase.auth.signUp({
+          const { data: signUpData, error: signUpError } = await supabase.auth.signUp({
             email,
             password,
             options: {
               data: username ? { username } : undefined,
               emailRedirectTo:
                 typeof window !== "undefined"
-                  ? `${window.location.origin}/auth/callback`
+                  ? `${window.location.origin}/auth/callback?next=/dashboard`
                   : undefined,
             },
           });
@@ -96,8 +97,15 @@ export function LoginScreen({ redirectTo = "/dashboard" }: LoginScreenProps) {
             setError(signUpError.message);
             return;
           }
+
+          if (!signUpData.session) {
+            setError("Check your email to confirm your account before signing in.");
+            return;
+          }
+
+          primeAccessToken(signUpData.session.access_token);
         } else {
-          const { error: signInError } = await supabase.auth.signInWithPassword({
+          const { data: signInData, error: signInError } = await supabase.auth.signInWithPassword({
             email,
             password,
           });
@@ -106,8 +114,11 @@ export function LoginScreen({ redirectTo = "/dashboard" }: LoginScreenProps) {
             setError(signInError.message);
             return;
           }
+
+          primeAccessToken(signInData.session?.access_token ?? null);
         }
 
+        router.refresh();
         router.replace(redirectTo);
       } catch (submitError) {
         setError(submitError instanceof Error ? submitError.message : "Something went wrong.");
@@ -128,7 +139,9 @@ export function LoginScreen({ redirectTo = "/dashboard" }: LoginScreenProps) {
 
     try {
       const redirectToUrl =
-        typeof window !== "undefined" ? `${window.location.origin}/auth/callback` : undefined;
+        typeof window !== "undefined"
+          ? `${window.location.origin}/auth/callback?next=/dashboard`
+          : undefined;
 
       const { error: oauthError } = await supabase.auth.signInWithOAuth({
         provider: "google",

--- a/lib/api/session.ts
+++ b/lib/api/session.ts
@@ -50,6 +50,10 @@ export const getAccessToken = async (): Promise<string | null> => {
   return accessTokenPromise;
 };
 
+export const primeAccessToken = (token: string | null) => {
+  cachedAccessToken = token;
+};
+
 export const clearCachedAccessToken = () => {
   cachedAccessToken = null;
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,40 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function middleware(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({
+    request,
+  });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
+          supabaseResponse = NextResponse.next({
+            request,
+          });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options)
+          );
+        },
+      },
+    }
+  );
+
+  // Refresh the session so server components see up-to-date auth cookies.
+  await supabase.auth.getUser();
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users had to log in twice before authentication would stick. Investigation found several gaps in the Supabase SSR auth flow:

1. **No middleware** — server components could not see refreshed auth cookies after client-side login
2. **No `router.refresh()`** after password login — stale server-rendered state on first navigation
3. **OAuth callback defaulted to `/`** — which re-checked session and could bounce users back to `/login`
4. **Sign-up redirected without a session** — email-confirmation accounts were sent to dashboard unauthenticated
5. **Dashboard had no auth guard** — inconsistent protection vs `/pre-read` and `/admin`
6. **API token cache race** — dashboard API calls could fire before the Bearer token was available

## Solution

- Add `middleware.ts` using the official Supabase SSR pattern to refresh sessions on every request
- After successful password login: prime the access token cache, call `router.refresh()`, then navigate
- OAuth callback now defaults to `/dashboard` with error handling on code exchange failure
- Sign-up without an immediate session shows a "check your email" message instead of redirecting
- Dashboard layout now redirects unauthenticated users to `/login` via `getUser()`
- Login page uses `getUser()` for the already-authenticated check

## Testing

- TypeScript compilation passes (`next build` compiles successfully; full build requires Supabase env vars)
- Manual verification recommended:
  - Email/password login → lands on dashboard on first attempt
  - Navigate to Pre-Read after login → stays authenticated
  - Google OAuth → lands on dashboard without second login
  - Sign-up with email confirmation → shows confirmation message, no false redirect

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f41c3-30a8-72ba-a219-230e9cc58044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f41c3-30a8-72ba-a219-230e9cc58044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

