### PR TITLE
Fix production build: Settings avatar cache types

### DIFF
--- a/components/SettingsScreen.tsx
+++ b/components/SettingsScreen.tsx
@@ -369,7 +369,7 @@ export function SettingsScreen({ onNavigate }: SettingsScreenProps = {}) {
       setProfileCache((current) =>
         current
           ? { ...current, avatar_url: nextUrl || null }
-          : current,
+          : null,
       );
       await queryClient.invalidateQueries({ queryKey: profileQueryKey });
       toast.success("Photo updated.");
@@ -407,7 +407,7 @@ export function SettingsScreen({ onNavigate }: SettingsScreenProps = {}) {
       setProfileForm((prev) => ({ ...prev, avatarUrl: "" }));
       setInitialProfileForm((prev) => ({ ...prev, avatarUrl: "" }));
       setProfileCache((current) =>
-        current ? { ...current, avatar_url: null } : current,
+        current ? { ...current, avatar_url: null } : null,
       );
       await queryClient.invalidateQueries({ queryKey: profileQueryKey });
       toast.success("Photo removed.");


### PR DESCRIPTION
## Summary
- Fix TypeScript error that failed the Vercel production build after PR #24
- `setProfileCache` callbacks now return `null` instead of `undefined` when no cached profile exists

## Test plan
- [ ] Vercel production build succeeds on main
- [ ] Settings photo upload / remove still works


Made with [Cursor](https://cursor.com)