### PR TITLE
Improve scripture picker UX and mobile button sizes

### DIFF
--- a/app/(admin)/admin/pre-read/PreReadForm.module.css
+++ b/app/(admin)/admin/pre-read/PreReadForm.module.css
@@ -157,7 +157,8 @@
 
 .field :global(input),
 .field :global(textarea),
-.field :global(button[data-slot="select-trigger"]) {
+.field :global(button[data-slot="select-trigger"]),
+.field :global(button[role="combobox"]) {
   width: 100%;
   max-width: 100%;
   min-width: 0;
@@ -237,9 +238,13 @@ textarea.control {
 .statusToggles {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65rem;
+  gap: 0.75rem;
   min-width: 0;
   max-width: 100%;
+}
+
+.statusToggles :global(button) {
+  border-radius: 0.85rem;
 }
 
 .arrayGroup {
@@ -463,6 +468,25 @@ textarea.control {
   .toolbarActions :global(a),
   .toolbarActions :global(button) {
     flex: 1 1 calc(50% - 0.4rem);
+    min-height: 3.5rem;
+  }
+
+  .statusToggles {
+    gap: 0.75rem;
+  }
+
+  .statusToggles :global(button) {
+    flex: 1 1 100%;
+    min-height: 3.5rem;
+    font-size: 1.05rem;
+  }
+
+  .formShell :global(button:not([role="combobox"])) {
+    min-height: 3.5rem;
+  }
+
+  .formShell :global(button[role="combobox"]) {
+    min-height: 3.5rem;
   }
 
   .control {
@@ -470,7 +494,7 @@ textarea.control {
     width: 100%;
     max-width: 100%;
     min-width: 0 !important;
-    min-height: 3.15rem;
+    min-height: 3.5rem;
     font-size: 1.05rem;
     padding: 0.85rem 1rem;
   }
@@ -491,9 +515,15 @@ textarea.control {
   .actions :global(a),
   .actions :global(button) {
     width: 100%;
+    min-height: 3.5rem;
   }
 
   .section {
     padding: 1.1rem 1rem;
+  }
+
+  .materialsActions :global(button),
+  .materialsActions :global(label) {
+    min-height: 3.5rem;
   }
 }

--- a/app/(admin)/admin/pre-read/PreReadForm.module.css
+++ b/app/(admin)/admin/pre-read/PreReadForm.module.css
@@ -205,7 +205,8 @@
 }
 
 button.control,
-.control[data-slot="select-trigger"] {
+.control[data-slot="select-trigger"],
+.control[role="combobox"] {
   display: flex;
   width: 100%;
   max-width: 100%;

--- a/app/(admin)/admin/pre-read/PreReadForm.tsx
+++ b/app/(admin)/admin/pre-read/PreReadForm.tsx
@@ -6,16 +6,11 @@ import { PlusCircle, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
+import { BookCombobox } from "@/components/bible/BookCombobox";
 import { Button } from "@/components/ui/button";
+import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import {
   createStudyLinkMaterial,
@@ -733,49 +728,39 @@ export default function PreReadForm({
           <div className={styles.fieldGrid}>
             <div className={styles.field}>
               <Label className={styles.label}>Book</Label>
-              <Select
+              <BookCombobox
+                books={books}
                 value={form.book || undefined}
+                valueKey="name"
                 onValueChange={handleBookSelect}
                 disabled={isLoadingBooks}
-              >
-                <SelectTrigger className={`${styles.control} w-full min-w-0 max-w-full`}>
-                  <SelectValue
-                    placeholder={
-                      isLoadingBooks ? "Loading books…" : "Choose a book"
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {books.map((book) => (
-                    <SelectItem key={book.id} value={book.name}>
-                      {book.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                placeholder={
+                  isLoadingBooks ? "Loading books…" : "Choose a book"
+                }
+                searchPlaceholder="Type a book (e.g. gen, john)…"
+                triggerClassName={`${styles.control} w-full min-w-0 max-w-full`}
+                aria-label="Bible book"
+              />
             </div>
             <div className={styles.field}>
               <Label className={styles.label}>Chapter</Label>
-              <Select
+              <Combobox
+                options={chapterOptions.map((chapter) => ({
+                  value: String(chapter),
+                  label: `Chapter ${chapter}`,
+                  keywords: [String(chapter)],
+                }))}
                 value={form.chapter || undefined}
                 onValueChange={handleChapterSelect}
                 disabled={!selectedBook}
-              >
-                <SelectTrigger className={`${styles.control} w-full min-w-0 max-w-full`}>
-                  <SelectValue
-                    placeholder={
-                      selectedBook ? "Choose a chapter" : "Select a book first"
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {chapterOptions.map((chapter) => (
-                    <SelectItem key={chapter} value={String(chapter)}>
-                      Chapter {chapter}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                placeholder={
+                  selectedBook ? "Choose a chapter" : "Select a book first"
+                }
+                searchPlaceholder="Type a chapter number…"
+                emptyMessage="No chapters match."
+                triggerClassName={`${styles.control} w-full min-w-0 max-w-full`}
+                aria-label="Chapter"
+              />
             </div>
             <div className={styles.field}>
               <Label htmlFor="verses_range" className={styles.label}>

--- a/app/(admin)/admin/pre-read/PreReadForm.tsx
+++ b/app/(admin)/admin/pre-read/PreReadForm.tsx
@@ -7,11 +7,13 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { BookCombobox } from "@/components/bible/BookCombobox";
+import { VerseRangePicker } from "@/components/bible/VerseRangePicker";
 import { Button } from "@/components/ui/button";
 import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { parseVerseRangeValue } from "@/lib/bible/verseRange";
 import {
   createStudyLinkMaterial,
   deleteStudyMaterial,
@@ -36,14 +38,14 @@ import { StudyMaterialsEditor } from "./StudyMaterialsEditor";
 
 /** Bigger tap targets on mobile; comfortable padded size from md up. */
 const btnSize =
-  "h-12 px-5 text-base md:h-10 md:px-5 md:text-sm";
-const btnIconSize = "size-11 md:size-9";
+  "h-14 min-h-14 px-6 text-base md:h-10 md:min-h-10 md:px-5 md:text-sm";
+const btnIconSize = "size-12 md:size-9";
 const btnSecondary =
-  "h-12 min-w-[8.5rem] px-6 text-base md:h-11 md:min-w-[7.5rem] md:px-6 md:text-sm border-[#e0c4b6] bg-white text-[#1a1a1a] hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26]";
+  "h-14 min-h-14 min-w-[8.5rem] px-6 text-base md:h-11 md:min-h-11 md:min-w-[7.5rem] md:px-6 md:text-sm border-[#e0c4b6] bg-white text-[#1a1a1a] hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26]";
 const btnPrimary =
-  "h-12 min-w-[8.5rem] px-6 text-base md:h-11 md:min-w-[7.5rem] md:px-6 md:text-sm border-0 bg-gradient-to-br from-[#d91f26] to-[#f28c00] text-white font-bold shadow-[0_10px_24px_color-mix(in_oklab,#d91f26_28%,transparent)] hover:brightness-105 hover:text-white";
+  "h-14 min-h-14 min-w-[8.5rem] px-6 text-base md:h-11 md:min-h-11 md:min-w-[7.5rem] md:px-6 md:text-sm border-0 bg-gradient-to-br from-[#d91f26] to-[#f28c00] text-white font-bold shadow-[0_10px_24px_color-mix(in_oklab,#d91f26_28%,transparent)] hover:brightness-105 hover:text-white";
 const btnStatus =
-  "h-12 flex-1 basis-28 min-w-0 px-4 text-base md:h-10 md:px-5 md:text-sm hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26]";
+  "h-14 min-h-14 flex-1 basis-[calc(50%-0.35rem)] min-w-0 px-4 text-base font-semibold md:h-11 md:min-h-11 md:basis-28 md:px-5 md:text-sm hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26]";
 
 type PreReadFormProps = {
   mode: "create" | "edit";
@@ -127,6 +129,10 @@ export default function PreReadForm({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [books, setBooks] = useState<BibleBookSummary[]>([]);
   const [isLoadingBooks, setIsLoadingBooks] = useState(true);
+  const [chapterVerseCount, setChapterVerseCount] = useState<number | null>(
+    null,
+  );
+  const [isLoadingVerses, setIsLoadingVerses] = useState(false);
   const [versesManuallyEdited, setVersesManuallyEdited] = useState(
     Boolean(initialData?.verses_range && initialData.verses_range.length > 0)
   );
@@ -280,16 +286,17 @@ export default function PreReadForm({
       !Number.isFinite(currentChapter) ||
       currentChapter < CHAPTER_MIN
     ) {
+      setChapterVerseCount(null);
+      setIsLoadingVerses(false);
       return;
     }
-    if (versesEditedRef.current) {
-      return;
-    }
+
     let active = true;
     const controller = new AbortController();
 
     const hydrateVerses = async () => {
       try {
+        setIsLoadingVerses(true);
         const response = await fetch(
           CHAPTER_ENDPOINT(currentBook, currentChapter),
           {
@@ -303,7 +310,11 @@ export default function PreReadForm({
         const verseCount = Array.isArray(payload.verses)
           ? payload.verses.length
           : 0;
-        if (!active || verseCount === 0) {
+        if (!active) {
+          return;
+        }
+        setChapterVerseCount(verseCount > 0 ? verseCount : null);
+        if (verseCount === 0 || versesEditedRef.current) {
           return;
         }
         setForm((prev) => {
@@ -322,6 +333,11 @@ export default function PreReadForm({
       } catch (error) {
         if (active && (error as Error).name !== "AbortError") {
           console.error("Failed to auto-fill verse range", error);
+          setChapterVerseCount(null);
+        }
+      } finally {
+        if (active) {
+          setIsLoadingVerses(false);
         }
       }
     };
@@ -341,6 +357,7 @@ export default function PreReadForm({
       chapter: "",
       versesRange: "",
     }));
+    setChapterVerseCount(null);
     setVersesManuallyEdited(false);
   };
 
@@ -348,7 +365,9 @@ export default function PreReadForm({
     setForm((prev) => ({
       ...prev,
       chapter: value,
+      versesRange: "",
     }));
+    setChapterVerseCount(null);
     setVersesManuallyEdited(false);
   };
 
@@ -420,27 +439,7 @@ export default function PreReadForm({
     }
   };
 
-  const parseVerseRange = (value: string) => {
-    const normalized = value.trim();
-    if (!normalized) {
-      return null;
-    }
-    const match = normalized.match(/^(\d+)(?:\s*-\s*(\d+))?$/);
-    if (!match) {
-      return null;
-    }
-    const start = Number(match[1]);
-    const end = match[2] ? Number(match[2]) : start;
-    if (
-      !Number.isFinite(start) ||
-      !Number.isFinite(end) ||
-      start <= 0 ||
-      end < start
-    ) {
-      return null;
-    }
-    return { start, end };
-  };
+  const parseVerseRange = parseVerseRangeValue;
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -762,19 +761,21 @@ export default function PreReadForm({
                 aria-label="Chapter"
               />
             </div>
-            <div className={styles.field}>
-              <Label htmlFor="verses_range" className={styles.label}>
-                Verses (optional)
-              </Label>
-              <Input
-                id="verses_range"
-                className={`${styles.control} w-full min-w-0 max-w-full`}
+            <div className={`${styles.field} ${styles.fieldWide}`}>
+              <Label className={styles.label}>Verses</Label>
+              <VerseRangePicker
+                verseCount={chapterVerseCount}
                 value={form.versesRange}
-                onChange={(event) => handleVersesChange(event.target.value)}
-                placeholder="1-26"
+                onValueChange={handleVersesChange}
+                disabled={isLoadingVerses}
+                triggerClassName={`${styles.control} w-full min-w-0 max-w-full`}
               />
               <p className={styles.helper}>
-                Leave blank for the full chapter.
+                {isLoadingVerses
+                  ? "Loading verse bounds…"
+                  : chapterVerseCount
+                    ? `Chapter has ${chapterVerseCount} verses. Defaults to the full chapter.`
+                    : "Pick a book and chapter to unlock verse bounds."}
               </p>
             </div>
             <div className={styles.field}>

--- a/app/(admin)/admin/pre-read/StudyMaterialsEditor.tsx
+++ b/app/(admin)/admin/pre-read/StudyMaterialsEditor.tsx
@@ -16,13 +16,13 @@ import {
 } from "./draft-materials";
 import styles from "./PreReadForm.module.css";
 
-const btnIconSize = "size-11 md:size-9";
+const btnIconSize = "size-12 md:size-9";
 const btnSecondary =
-  "h-12 min-w-[8.5rem] px-6 text-base md:h-11 md:min-w-[7.5rem] md:px-6 md:text-sm border-[#e0c4b6] bg-white text-[#1a1a1a] hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26]";
+  "h-14 min-h-14 min-w-[8.5rem] px-6 text-base md:h-11 md:min-h-11 md:min-w-[7.5rem] md:px-6 md:text-sm border-[#e0c4b6] bg-white text-[#1a1a1a] hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26]";
 const btnPrimary =
-  "h-12 min-w-[8.5rem] px-6 text-base md:h-11 md:min-w-[7.5rem] md:px-6 md:text-sm border-0 bg-gradient-to-br from-[#d91f26] to-[#f28c00] text-white font-bold shadow-[0_10px_24px_color-mix(in_oklab,#d91f26_28%,transparent)] hover:brightness-105 hover:text-white";
+  "h-14 min-h-14 min-w-[8.5rem] px-6 text-base md:h-11 md:min-h-11 md:min-w-[7.5rem] md:px-6 md:text-sm border-0 bg-gradient-to-br from-[#d91f26] to-[#f28c00] text-white font-bold shadow-[0_10px_24px_color-mix(in_oklab,#d91f26_28%,transparent)] hover:brightness-105 hover:text-white";
 const uploadBtn =
-  "relative inline-flex h-12 min-w-[8.5rem] cursor-pointer items-center justify-center gap-2 overflow-hidden rounded-md bg-gradient-to-br from-[#d91f26] to-[#f28c00] px-6 text-base font-bold text-white hover:brightness-105 md:h-11 md:min-w-[7.5rem] md:px-6 md:text-sm";
+  "relative inline-flex h-14 min-h-14 min-w-[8.5rem] cursor-pointer items-center justify-center gap-2 overflow-hidden rounded-md bg-gradient-to-br from-[#d91f26] to-[#f28c00] px-6 text-base font-bold text-white hover:brightness-105 md:h-11 md:min-h-11 md:min-w-[7.5rem] md:px-6 md:text-sm";
 
 type StudyMaterialsEditorProps = {
   materials: DraftMaterial[];

--- a/components/bible/BookCombobox.tsx
+++ b/components/bible/BookCombobox.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  Combobox,
+  type ComboboxProps,
+} from "@/components/ui/combobox";
+import { getBookSearchKeywords } from "@/lib/bible/filterBooks";
+import type { BibleBookSummary } from "@/types/bible";
+
+export type BookComboboxProps = {
+  books: BibleBookSummary[];
+  /** Selected book id or name, depending on `valueKey`. */
+  value?: string;
+  onValueChange: (value: string, book: BibleBookSummary) => void;
+  /**
+   * Which field to use as the combobox value.
+   * Pre-read forms store book **name**; reader/memory/notes store book **id**.
+   */
+  valueKey?: "id" | "name";
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+  disabled?: boolean;
+  className?: string;
+  triggerClassName?: string;
+  id?: string;
+  "aria-label"?: string;
+};
+
+/**
+ * Client-side Bible book typeahead. Reuses the generic Combobox and matches
+ * on name, abbreviation, and shared aliases (e.g. "gen", "1 cor").
+ */
+export function BookCombobox({
+  books,
+  value,
+  onValueChange,
+  valueKey = "id",
+  placeholder = "Choose a book",
+  searchPlaceholder = "Search books…",
+  emptyMessage = "No books match.",
+  disabled = false,
+  className,
+  triggerClassName,
+  id,
+  "aria-label": ariaLabel = "Bible book",
+}: BookComboboxProps) {
+  const options = React.useMemo(
+    () =>
+      books.map((book) => ({
+        value: valueKey === "name" ? book.name : book.id,
+        label: book.name,
+        keywords: getBookSearchKeywords(book),
+      })),
+    [books, valueKey],
+  );
+
+  const bookByValue = React.useMemo(() => {
+    const map = new Map<string, BibleBookSummary>();
+    for (const book of books) {
+      map.set(valueKey === "name" ? book.name : book.id, book);
+    }
+    return map;
+  }, [books, valueKey]);
+
+  const handleChange: ComboboxProps["onValueChange"] = (next) => {
+    const book = bookByValue.get(next);
+    if (!book) return;
+    onValueChange(next, book);
+  };
+
+  return (
+    <Combobox
+      id={id}
+      options={options}
+      value={value}
+      onValueChange={handleChange}
+      placeholder={placeholder}
+      searchPlaceholder={searchPlaceholder}
+      emptyMessage={emptyMessage}
+      disabled={disabled}
+      className={className}
+      triggerClassName={triggerClassName}
+      aria-label={ariaLabel}
+    />
+  );
+}

--- a/components/bible/VerseRangePicker.module.css
+++ b/components/bible/VerseRangePicker.module.css
@@ -1,0 +1,40 @@
+.root {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 0.55rem 0.65rem;
+  align-items: end;
+  width: 100%;
+  min-width: 0;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.subLabel {
+  font-size: 0.78rem;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  color: #6b5a52;
+}
+
+.separator {
+  align-self: center;
+  padding-bottom: 0.15rem;
+  color: #6b5a52;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+@media (max-width: 419px) {
+  .root {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .separator {
+    display: none;
+  }
+}

--- a/components/bible/VerseRangePicker.tsx
+++ b/components/bible/VerseRangePicker.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { Combobox } from "@/components/ui/combobox";
+import {
+  formatVerseRange,
+  parseVerseRangeValue,
+} from "@/lib/bible/verseRange";
+
+import styles from "./VerseRangePicker.module.css";
+
+export type VerseRangePickerProps = {
+  /** Total verses in the selected chapter; null until book+chapter are known. */
+  verseCount: number | null;
+  /** Stored range string, e.g. `"1-26"` or `"5"`. */
+  value: string;
+  onValueChange: (range: string) => void;
+  disabled?: boolean;
+  className?: string;
+  triggerClassName?: string;
+};
+
+export { formatVerseRange, parseVerseRangeValue } from "@/lib/bible/verseRange";
+
+/**
+ * Client-side from/to verse dropdowns. Bounds come from the loaded chapter.
+ */
+export function VerseRangePicker({
+  verseCount,
+  value,
+  onValueChange,
+  disabled = false,
+  className,
+  triggerClassName,
+}: VerseRangePickerProps) {
+  const ready = typeof verseCount === "number" && verseCount > 0;
+  const parsed = parseVerseRangeValue(value);
+  const start = parsed?.start;
+  const end = parsed?.end;
+
+  const startOptions = useMemo(() => {
+    if (!ready || !verseCount) return [];
+    return Array.from({ length: verseCount }, (_value, index) => {
+      const verse = index + 1;
+      return {
+        value: String(verse),
+        label: String(verse),
+        keywords: [String(verse)],
+      };
+    });
+  }, [ready, verseCount]);
+
+  const endOptions = useMemo(() => {
+    if (!ready || !verseCount) return [];
+    const min = start && start >= 1 ? start : 1;
+    return Array.from({ length: verseCount - min + 1 }, (_value, index) => {
+      const verse = min + index;
+      return {
+        value: String(verse),
+        label: String(verse),
+        keywords: [String(verse)],
+      };
+    });
+  }, [ready, verseCount, start]);
+
+  const isDisabled = disabled || !ready;
+
+  const handleStartChange = (nextStartRaw: string) => {
+    if (!verseCount) return;
+    const nextStart = Number.parseInt(nextStartRaw, 10);
+    if (!Number.isFinite(nextStart)) return;
+    const nextEnd =
+      end && end >= nextStart ? end : Math.max(nextStart, end ?? nextStart);
+    const clampedEnd = Math.min(Math.max(nextEnd, nextStart), verseCount);
+    onValueChange(formatVerseRange(nextStart, clampedEnd));
+  };
+
+  const handleEndChange = (nextEndRaw: string) => {
+    if (!verseCount) return;
+    const nextEnd = Number.parseInt(nextEndRaw, 10);
+    if (!Number.isFinite(nextEnd)) return;
+    const nextStart = start && start >= 1 ? Math.min(start, nextEnd) : 1;
+    onValueChange(formatVerseRange(nextStart, nextEnd));
+  };
+
+  return (
+    <div className={[styles.root, className].filter(Boolean).join(" ")}>
+      <div className={styles.field}>
+        <span className={styles.subLabel}>From</span>
+        <Combobox
+          options={startOptions}
+          value={start ? String(start) : undefined}
+          onValueChange={handleStartChange}
+          disabled={isDisabled}
+          placeholder={ready ? "Start" : "Select chapter first"}
+          searchPlaceholder="Verse…"
+          emptyMessage="No verses."
+          triggerClassName={triggerClassName}
+          aria-label="Start verse"
+        />
+      </div>
+      <span className={styles.separator} aria-hidden="true">
+        to
+      </span>
+      <div className={styles.field}>
+        <span className={styles.subLabel}>To</span>
+        <Combobox
+          options={endOptions}
+          value={end ? String(end) : undefined}
+          onValueChange={handleEndChange}
+          disabled={isDisabled || !start}
+          placeholder={ready ? "End" : "Select chapter first"}
+          searchPlaceholder="Verse…"
+          emptyMessage="No verses."
+          triggerClassName={triggerClassName}
+          aria-label="End verse"
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/ui/Combobox.module.css
+++ b/components/ui/Combobox.module.css
@@ -1,0 +1,194 @@
+.root {
+  width: 100%;
+  min-width: 0;
+}
+
+.trigger {
+  box-sizing: border-box;
+  display: flex;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 3.5rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem;
+  border-radius: 0.8rem;
+  border: 1.5px solid #e0c4b6;
+  background: #fff8f4;
+  padding: 0.85rem 1rem;
+  color: #1a1a1a;
+  font-size: 1.05rem;
+  font-weight: 500;
+  line-height: 1.35;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease,
+    background 150ms ease;
+}
+
+.trigger:hover:not(:disabled) {
+  border-color: color-mix(in oklab, #d91f26 35%, #e0c4b6);
+  background: #ffffff;
+}
+
+.trigger:focus-visible {
+  outline: none;
+  border-color: #d91f26;
+  background: #ffffff;
+  box-shadow: 0 0 0 3px color-mix(in oklab, #d91f26 18%, transparent);
+}
+
+.trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.trigger[data-placeholder] {
+  color: #6b5a52;
+  font-weight: 450;
+}
+
+.triggerLabel {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chevron {
+  width: 1.1rem;
+  height: 1.1rem;
+  flex-shrink: 0;
+  color: #8a7268;
+  opacity: 0.9;
+}
+
+.content {
+  width: var(--radix-popover-trigger-width);
+  max-width: min(100vw - 1.5rem, 28rem);
+  padding: 0;
+  overflow: hidden;
+  border-radius: 0.9rem;
+  border: 1.5px solid #e8cfc4;
+  background: #ffffff;
+  box-shadow:
+    0 18px 40px color-mix(in oklab, #1a1a1a 12%, transparent),
+    0 2px 8px color-mix(in oklab, #d91f26 8%, transparent);
+}
+
+.searchRow {
+  padding: 0.7rem;
+  border-bottom: 1px solid #f0ddd4;
+  background: #fff8f4;
+}
+
+.searchInput {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 2.85rem;
+  border-radius: 0.7rem;
+  border: 1.5px solid #e0c4b6;
+  background: #ffffff;
+  padding: 0.65rem 0.85rem;
+  color: #1a1a1a;
+  font-size: 1rem;
+  line-height: 1.35;
+  outline: none;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.searchInput::placeholder {
+  color: #8a7268;
+}
+
+.searchInput:focus {
+  border-color: #d91f26;
+  box-shadow: 0 0 0 3px color-mix(in oklab, #d91f26 16%, transparent);
+}
+
+.list {
+  max-height: 16.5rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0.4rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+.empty {
+  margin: 0;
+  padding: 1rem 0.75rem;
+  text-align: center;
+  color: #6b5a52;
+  font-size: 0.95rem;
+}
+
+.option {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 0.55rem;
+  border: 0;
+  border-radius: 0.65rem;
+  background: transparent;
+  padding: 0.8rem 0.85rem;
+  color: #1a1a1a;
+  font-size: 1rem;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.option:hover,
+.option[data-active] {
+  background: color-mix(in oklab, #d91f26 10%, #fff5f0);
+  color: #1a1a1a;
+}
+
+.option[data-selected] {
+  background: color-mix(in oklab, #d91f26 14%, #ffe8dc);
+  color: #1a1a1a;
+}
+
+.option[data-selected][data-active] {
+  background: color-mix(in oklab, #d91f26 18%, #ffe0d0);
+}
+
+.optionLabel {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.check {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  color: #d91f26;
+}
+
+@media (min-width: 720px) {
+  .trigger {
+    min-height: 3rem;
+    padding: 0.75rem 0.95rem;
+    font-size: 1rem;
+  }
+
+  .searchInput {
+    min-height: 2.5rem;
+    font-size: 0.95rem;
+  }
+
+  .option {
+    padding: 0.65rem 0.75rem;
+    font-size: 0.95rem;
+  }
+}

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -4,14 +4,14 @@ import * as React from "react";
 import { CheckIcon, ChevronDownIcon } from "lucide-react";
 
 import { filterComboboxOptions } from "@/lib/bible/filterBooks";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/components/ui/utils";
+
+import styles from "./Combobox.module.css";
 
 export type ComboboxOption = {
   value: string;
@@ -132,39 +132,38 @@ export function Combobox({
   };
 
   return (
-    <div className={cn("w-full min-w-0", className)}>
+    <div className={cn(styles.root, className)}>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <Button
+          <button
             id={id}
             type="button"
-            variant="outline"
             role="combobox"
             aria-expanded={open}
+            aria-controls={id ? `${id}-listbox` : undefined}
             aria-label={ariaLabel}
             disabled={disabled}
-            className={cn(
-              "border-input data-[placeholder]:text-muted-foreground flex h-9 w-full min-w-0 items-center justify-between gap-2 rounded-md border bg-input-background px-3 py-2 text-sm font-normal whitespace-nowrap shadow-none transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
-              !selected && "text-muted-foreground",
-              triggerClassName,
-            )}
+            data-placeholder={!selected ? "" : undefined}
+            className={cn(styles.trigger, triggerClassName)}
           >
-            <span className="min-w-0 flex-1 truncate text-left">
+            <span className={styles.triggerLabel}>
               {selected?.label ?? placeholder}
             </span>
-            <ChevronDownIcon className="size-4 shrink-0 opacity-50" />
-          </Button>
+            <ChevronDownIcon className={styles.chevron} aria-hidden="true" />
+          </button>
         </PopoverTrigger>
         <PopoverContent
           align="start"
+          sideOffset={6}
           className={cn(
-            "w-[var(--radix-popover-trigger-width)] p-0",
+            "w-[var(--radix-popover-trigger-width)] max-w-[min(100vw-1.5rem,28rem)] border-0 bg-transparent p-0 shadow-none",
+            styles.content,
             contentClassName,
           )}
           onOpenAutoFocus={(event) => event.preventDefault()}
         >
-          <div className="border-b p-2">
-            <Input
+          <div className={styles.searchRow}>
+            <input
               ref={searchRef}
               value={query}
               onChange={(event) => {
@@ -173,7 +172,7 @@ export function Combobox({
               }}
               onKeyDown={onSearchKeyDown}
               placeholder={searchPlaceholder}
-              className="h-10"
+              className={styles.searchInput}
               aria-autocomplete="list"
               aria-controls={id ? `${id}-listbox` : undefined}
               autoComplete="off"
@@ -185,12 +184,10 @@ export function Combobox({
             ref={listRef}
             id={id ? `${id}-listbox` : undefined}
             role="listbox"
-            className="max-h-60 overflow-y-auto overscroll-contain p-1"
+            className={styles.list}
           >
             {filtered.length === 0 ? (
-              <p className="text-muted-foreground px-2 py-3 text-center text-sm">
-                {emptyMessage}
-              </p>
+              <p className={styles.empty}>{emptyMessage}</p>
             ) : (
               filtered.map((option, index) => {
                 const isSelected = option.value === value;
@@ -202,19 +199,15 @@ export function Combobox({
                     role="option"
                     aria-selected={isSelected}
                     data-combobox-index={index}
-                    className={cn(
-                      "relative flex w-full cursor-default items-center gap-2 rounded-md px-2.5 py-2.5 text-left text-sm outline-hidden transition-colors",
-                      isActive && "bg-accent text-accent-foreground",
-                      isSelected && !isActive && "bg-accent/50",
-                    )}
+                    data-active={isActive ? "" : undefined}
+                    data-selected={isSelected ? "" : undefined}
+                    className={styles.option}
                     onMouseEnter={() => setActiveIndex(index)}
                     onClick={() => selectValue(option.value)}
                   >
-                    <span className="min-w-0 flex-1 truncate">
-                      {option.label}
-                    </span>
+                    <span className={styles.optionLabel}>{option.label}</span>
                     {isSelected ? (
-                      <CheckIcon className="size-4 shrink-0 opacity-70" />
+                      <CheckIcon className={styles.check} aria-hidden="true" />
                     ) : null}
                   </button>
                 );

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import * as React from "react";
+import { CheckIcon, ChevronDownIcon } from "lucide-react";
+
+import { filterComboboxOptions } from "@/lib/bible/filterBooks";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/components/ui/utils";
+
+export type ComboboxOption = {
+  value: string;
+  label: string;
+  /** Extra client-side match terms (aliases, abbreviations, etc.). */
+  keywords?: string[];
+};
+
+export type ComboboxProps = {
+  options: ComboboxOption[];
+  value?: string;
+  onValueChange: (value: string) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+  disabled?: boolean;
+  className?: string;
+  triggerClassName?: string;
+  contentClassName?: string;
+  id?: string;
+  "aria-label"?: string;
+};
+
+/**
+ * Reusable client-side typeahead + dropdown.
+ * Filters options locally by label, value, and optional keywords.
+ */
+export function Combobox({
+  options,
+  value,
+  onValueChange,
+  placeholder = "Select…",
+  searchPlaceholder = "Search…",
+  emptyMessage = "No results.",
+  disabled = false,
+  className,
+  triggerClassName,
+  contentClassName,
+  id,
+  "aria-label": ariaLabel,
+}: ComboboxProps) {
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState("");
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  const searchRef = React.useRef<HTMLInputElement>(null);
+  const listRef = React.useRef<HTMLDivElement>(null);
+
+  const selected = React.useMemo(
+    () => options.find((option) => option.value === value) ?? null,
+    [options, value],
+  );
+
+  const filtered = React.useMemo(
+    () => filterComboboxOptions(options, query),
+    [options, query],
+  );
+
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setQuery("");
+    const selectedIndex = options.findIndex((option) => option.value === value);
+    setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
+    const frame = window.requestAnimationFrame(() => {
+      searchRef.current?.focus();
+    });
+    return () => window.cancelAnimationFrame(frame);
+    // Reset search UI whenever the popover opens.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  React.useEffect(() => {
+    setActiveIndex((prev) => {
+      if (filtered.length === 0) return 0;
+      return Math.min(prev, filtered.length - 1);
+    });
+  }, [filtered.length]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const active = listRef.current?.querySelector<HTMLElement>(
+      `[data-combobox-index="${activeIndex}"]`,
+    );
+    active?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, open, filtered]);
+
+  const selectValue = (next: string) => {
+    onValueChange(next);
+    setOpen(false);
+  };
+
+  const onSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      if (filtered.length === 0) return;
+      setActiveIndex((prev) => (prev + 1) % filtered.length);
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      if (filtered.length === 0) return;
+      setActiveIndex((prev) => (prev - 1 + filtered.length) % filtered.length);
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      const option = filtered[activeIndex];
+      if (option) {
+        selectValue(option.value);
+      }
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div className={cn("w-full min-w-0", className)}>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            id={id}
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            aria-label={ariaLabel}
+            disabled={disabled}
+            className={cn(
+              "border-input data-[placeholder]:text-muted-foreground flex h-9 w-full min-w-0 items-center justify-between gap-2 rounded-md border bg-input-background px-3 py-2 text-sm font-normal whitespace-nowrap shadow-none transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+              !selected && "text-muted-foreground",
+              triggerClassName,
+            )}
+          >
+            <span className="min-w-0 flex-1 truncate text-left">
+              {selected?.label ?? placeholder}
+            </span>
+            <ChevronDownIcon className="size-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          className={cn(
+            "w-[var(--radix-popover-trigger-width)] p-0",
+            contentClassName,
+          )}
+          onOpenAutoFocus={(event) => event.preventDefault()}
+        >
+          <div className="border-b p-2">
+            <Input
+              ref={searchRef}
+              value={query}
+              onChange={(event) => {
+                setQuery(event.target.value);
+                setActiveIndex(0);
+              }}
+              onKeyDown={onSearchKeyDown}
+              placeholder={searchPlaceholder}
+              className="h-10"
+              aria-autocomplete="list"
+              aria-controls={id ? `${id}-listbox` : undefined}
+              autoComplete="off"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+          </div>
+          <div
+            ref={listRef}
+            id={id ? `${id}-listbox` : undefined}
+            role="listbox"
+            className="max-h-60 overflow-y-auto overscroll-contain p-1"
+          >
+            {filtered.length === 0 ? (
+              <p className="text-muted-foreground px-2 py-3 text-center text-sm">
+                {emptyMessage}
+              </p>
+            ) : (
+              filtered.map((option, index) => {
+                const isSelected = option.value === value;
+                const isActive = index === activeIndex;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    role="option"
+                    aria-selected={isSelected}
+                    data-combobox-index={index}
+                    className={cn(
+                      "relative flex w-full cursor-default items-center gap-2 rounded-md px-2.5 py-2.5 text-left text-sm outline-hidden transition-colors",
+                      isActive && "bg-accent text-accent-foreground",
+                      isSelected && !isActive && "bg-accent/50",
+                    )}
+                    onMouseEnter={() => setActiveIndex(index)}
+                    onClick={() => selectValue(option.value)}
+                  >
+                    <span className="min-w-0 flex-1 truncate">
+                      {option.label}
+                    </span>
+                    {isSelected ? (
+                      <CheckIcon className="size-4 shrink-0 opacity-70" />
+                    ) : null}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/lib/bible/bookAliases.ts
+++ b/lib/bible/bookAliases.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared book name → alias list used for speech parsing and typeahead matching.
+ * Keep aliases lowercase; callers should normalise query text the same way.
+ */
+
+export type BookAliasEntry = {
+  name: string;
+  aliases: string[];
+};
+
+const BASE_BOOKS: Array<{ name: string; aliases?: string[] }> = [
+  { name: "Genesis", aliases: ["gen", "genesis"] },
+  { name: "Exodus", aliases: ["ex", "exo", "exodus"] },
+  { name: "Leviticus", aliases: ["lev", "leviticus"] },
+  { name: "Numbers", aliases: ["num", "numbers"] },
+  { name: "Deuteronomy", aliases: ["deut", "deuteronomy"] },
+  { name: "Joshua", aliases: ["josh", "joshua"] },
+  { name: "Judges", aliases: ["judg", "judges"] },
+  { name: "Ruth" },
+  { name: "1 Samuel", aliases: ["1 samuel", "first samuel", "1 sam"] },
+  { name: "2 Samuel", aliases: ["2 samuel", "second samuel", "2 sam"] },
+  { name: "1 Kings", aliases: ["1 kings", "first kings", "1 kgs"] },
+  { name: "2 Kings", aliases: ["2 kings", "second kings", "2 kgs"] },
+  {
+    name: "1 Chronicles",
+    aliases: ["1 chronicles", "first chronicles", "1 chron"],
+  },
+  {
+    name: "2 Chronicles",
+    aliases: ["2 chronicles", "second chronicles", "2 chron"],
+  },
+  { name: "Ezra" },
+  { name: "Nehemiah", aliases: ["neh", "nehemiah"] },
+  { name: "Esther", aliases: ["est", "esther"] },
+  { name: "Job" },
+  { name: "Psalm", aliases: ["psalm", "psalms", "ps"] },
+  { name: "Proverbs", aliases: ["prov", "proverbs"] },
+  { name: "Ecclesiastes", aliases: ["ecclesiastes", "ecc", "eccles"] },
+  {
+    name: "Song of Solomon",
+    aliases: ["song of solomon", "song of songs", "songs"],
+  },
+  { name: "Isaiah", aliases: ["isa", "isaiah"] },
+  { name: "Jeremiah", aliases: ["jer", "jeremiah"] },
+  { name: "Lamentations", aliases: ["lam", "lamentations"] },
+  { name: "Ezekiel", aliases: ["ezek", "ezekiel"] },
+  { name: "Daniel", aliases: ["dan", "daniel"] },
+  { name: "Hosea", aliases: ["hos", "hosea"] },
+  { name: "Joel" },
+  { name: "Amos" },
+  { name: "Obadiah", aliases: ["obadiah", "obad"] },
+  { name: "Jonah", aliases: ["jonah", "jon"] },
+  { name: "Micah", aliases: ["mic", "micah"] },
+  { name: "Nahum", aliases: ["nah", "nahum"] },
+  { name: "Habakkuk", aliases: ["hab", "habakkuk"] },
+  { name: "Zephaniah", aliases: ["zeph", "zephaniah"] },
+  { name: "Haggai", aliases: ["hag", "haggai"] },
+  { name: "Zechariah", aliases: ["zech", "zechariah"] },
+  { name: "Malachi", aliases: ["mal", "malachi"] },
+  { name: "Matthew", aliases: ["matt", "matthew"] },
+  { name: "Mark" },
+  { name: "Luke" },
+  { name: "John" },
+  { name: "Acts", aliases: ["acts", "acts of the apostles"] },
+  { name: "Romans", aliases: ["rom", "romans"] },
+  {
+    name: "1 Corinthians",
+    aliases: ["1 corinthians", "first corinthians", "1 cor"],
+  },
+  {
+    name: "2 Corinthians",
+    aliases: ["2 corinthians", "second corinthians", "2 cor"],
+  },
+  { name: "Galatians", aliases: ["gal", "galatians"] },
+  { name: "Ephesians", aliases: ["eph", "ephesians"] },
+  { name: "Philippians", aliases: ["phil", "philippians"] },
+  { name: "Colossians", aliases: ["col", "colossians"] },
+  {
+    name: "1 Thessalonians",
+    aliases: ["1 thessalonians", "first thessalonians", "1 thess"],
+  },
+  {
+    name: "2 Thessalonians",
+    aliases: ["2 thessalonians", "second thessalonians", "2 thess"],
+  },
+  { name: "1 Timothy", aliases: ["1 timothy", "first timothy", "1 tim"] },
+  { name: "2 Timothy", aliases: ["2 timothy", "second timothy", "2 tim"] },
+  { name: "Titus" },
+  { name: "Philemon", aliases: ["philem", "philemon"] },
+  { name: "Hebrews", aliases: ["heb", "hebrews"] },
+  { name: "James", aliases: ["jam", "james"] },
+  { name: "1 Peter", aliases: ["1 peter", "first peter", "1 pet"] },
+  { name: "2 Peter", aliases: ["2 peter", "second peter", "2 pet"] },
+  { name: "1 John", aliases: ["1 john", "first john", "1 jn"] },
+  { name: "2 John", aliases: ["2 john", "second john", "2 jn"] },
+  { name: "3 John", aliases: ["3 john", "third john", "3 jn"] },
+  { name: "Jude" },
+  { name: "Revelation", aliases: ["rev", "revelation", "revelations"] },
+];
+
+function buildAliases(name: string, extras?: string[]): string[] {
+  const aliasSet = new Set<string>([name.toLowerCase()]);
+
+  if (extras) {
+    extras.forEach((alias) => aliasSet.add(alias.toLowerCase()));
+  }
+
+  if (/^[1-3]/.test(name)) {
+    const parts = name.split(" ");
+    const number = parts[0];
+    const rest = parts.slice(1).join(" ");
+    const ordinal =
+      number === "1" ? "first" : number === "2" ? "second" : "third";
+    aliasSet.add(`${number} ${rest}`.toLowerCase());
+    aliasSet.add(`${ordinal} ${rest}`.toLowerCase());
+  }
+
+  return Array.from(aliasSet).sort((a, b) => b.length - a.length);
+}
+
+export const BOOK_ALIASES: BookAliasEntry[] = BASE_BOOKS.map(
+  ({ name, aliases }) => ({
+    name,
+    aliases: buildAliases(name, aliases),
+  }),
+);
+
+const ALIASES_BY_NAME = new Map(
+  BOOK_ALIASES.map((entry) => [entry.name.toLowerCase(), entry.aliases]),
+);
+
+/** Returns lowercase aliases for a canonical book name (empty if unknown). */
+export function getAliasesForBookName(name: string): string[] {
+  return ALIASES_BY_NAME.get(name.toLowerCase()) ?? [name.toLowerCase()];
+}

--- a/lib/bible/filterBooks.ts
+++ b/lib/bible/filterBooks.ts
@@ -1,0 +1,78 @@
+import { getAliasesForBookName } from "./bookAliases";
+import type { BibleBookSummary } from "@/types/bible";
+
+export type BookSearchable = Pick<
+  BibleBookSummary,
+  "id" | "name" | "abbreviation"
+>;
+
+export type ComboboxFilterOption = {
+  value: string;
+  label: string;
+  keywords?: string[];
+};
+
+const normaliseQuery = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+/**
+ * Client-side filter for generic combobox options (label + optional keywords).
+ */
+export function filterComboboxOptions<T extends ComboboxFilterOption>(
+  options: T[],
+  query: string,
+): T[] {
+  const needle = normaliseQuery(query);
+  if (!needle) {
+    return options;
+  }
+
+  return options.filter((option) => {
+    const haystacks = [
+      option.label,
+      option.value,
+      ...(option.keywords ?? []),
+    ].map(normaliseQuery);
+
+    return haystacks.some(
+      (haystack) =>
+        haystack.includes(needle) ||
+        haystack.split(" ").some((token) => token.startsWith(needle)),
+    );
+  });
+}
+
+/**
+ * Build searchable keywords for a Bible book (name, abbreviation, aliases).
+ */
+export function getBookSearchKeywords(
+  book: Pick<BibleBookSummary, "name" | "abbreviation">,
+): string[] {
+  const keywords = new Set<string>(getAliasesForBookName(book.name));
+  if (book.abbreviation) {
+    keywords.add(book.abbreviation.toLowerCase());
+  }
+  return Array.from(keywords);
+}
+
+/**
+ * Client-side book typeahead filter. Matches name, abbreviation, and aliases
+ * (e.g. "gen" → Genesis, "1 cor" → 1 Corinthians).
+ */
+export function filterBooks<T extends BookSearchable>(
+  books: T[],
+  query: string,
+): T[] {
+  const options = books.map((book) => ({
+    value: book.id,
+    label: book.name,
+    keywords: getBookSearchKeywords(book),
+    book,
+  }));
+
+  return filterComboboxOptions(options, query).map((option) => option.book);
+}

--- a/lib/bible/parseReferenceFromText.ts
+++ b/lib/bible/parseReferenceFromText.ts
@@ -1,3 +1,8 @@
+import {
+  BOOK_ALIASES,
+  type BookAliasEntry,
+} from "./bookAliases";
+
 export type ParsedReference = {
   book: string | null;
   chapter: number | null;
@@ -6,102 +11,7 @@ export type ParsedReference = {
   bodyText: string;
 };
 
-type BookAlias = {
-  name: string;
-  aliases: string[];
-};
-
-const BASE_BOOKS: Array<{ name: string; aliases?: string[] }> = [
-  { name: "Genesis", aliases: ["gen", "genesis"] },
-  { name: "Exodus", aliases: ["ex", "exo", "exodus"] },
-  { name: "Leviticus", aliases: ["lev", "leviticus"] },
-  { name: "Numbers", aliases: ["num", "numbers"] },
-  { name: "Deuteronomy", aliases: ["deut", "deuteronomy"] },
-  { name: "Joshua", aliases: ["josh", "joshua"] },
-  { name: "Judges", aliases: ["judg", "judges"] },
-  { name: "Ruth" },
-  { name: "1 Samuel", aliases: ["1 samuel", "first samuel", "1 sam"] },
-  { name: "2 Samuel", aliases: ["2 samuel", "second samuel", "2 sam"] },
-  { name: "1 Kings", aliases: ["1 kings", "first kings", "1 kgs"] },
-  { name: "2 Kings", aliases: ["2 kings", "second kings", "2 kgs"] },
-  { name: "1 Chronicles", aliases: ["1 chronicles", "first chronicles", "1 chron"] },
-  { name: "2 Chronicles", aliases: ["2 chronicles", "second chronicles", "2 chron"] },
-  { name: "Ezra" },
-  { name: "Nehemiah", aliases: ["neh", "nehemiah"] },
-  { name: "Esther", aliases: ["est", "esther"] },
-  { name: "Job" },
-  { name: "Psalm", aliases: ["psalm", "psalms", "ps"] },
-  { name: "Proverbs", aliases: ["prov", "proverbs"] },
-  { name: "Ecclesiastes", aliases: ["ecclesiastes", "ecc", "eccles"] },
-  { name: "Song of Solomon", aliases: ["song of solomon", "song of songs", "songs"] },
-  { name: "Isaiah", aliases: ["isa", "isaiah"] },
-  { name: "Jeremiah", aliases: ["jer", "jeremiah"] },
-  { name: "Lamentations", aliases: ["lam", "lamentations"] },
-  { name: "Ezekiel", aliases: ["ezek", "ezekiel"] },
-  { name: "Daniel", aliases: ["dan", "daniel"] },
-  { name: "Hosea", aliases: ["hos", "hosea"] },
-  { name: "Joel" },
-  { name: "Amos" },
-  { name: "Obadiah", aliases: ["obadiah", "obad"] },
-  { name: "Jonah", aliases: ["jonah", "jon"] },
-  { name: "Micah", aliases: ["mic", "micah"] },
-  { name: "Nahum", aliases: ["nah", "nahum"] },
-  { name: "Habakkuk", aliases: ["hab", "habakkuk"] },
-  { name: "Zephaniah", aliases: ["zeph", "zephaniah"] },
-  { name: "Haggai", aliases: ["hag", "haggai"] },
-  { name: "Zechariah", aliases: ["zech", "zechariah"] },
-  { name: "Malachi", aliases: ["mal", "malachi"] },
-  { name: "Matthew", aliases: ["matt", "matthew"] },
-  { name: "Mark" },
-  { name: "Luke" },
-  { name: "John" },
-  { name: "Acts", aliases: ["acts", "acts of the apostles"] },
-  { name: "Romans", aliases: ["rom", "romans"] },
-  { name: "1 Corinthians", aliases: ["1 corinthians", "first corinthians", "1 cor"] },
-  { name: "2 Corinthians", aliases: ["2 corinthians", "second corinthians", "2 cor"] },
-  { name: "Galatians", aliases: ["gal", "galatians"] },
-  { name: "Ephesians", aliases: ["eph", "ephesians"] },
-  { name: "Philippians", aliases: ["phil", "philippians"] },
-  { name: "Colossians", aliases: ["col", "colossians"] },
-  { name: "1 Thessalonians", aliases: ["1 thessalonians", "first thessalonians", "1 thess"] },
-  { name: "2 Thessalonians", aliases: ["2 thessalonians", "second thessalonians", "2 thess"] },
-  { name: "1 Timothy", aliases: ["1 timothy", "first timothy", "1 tim"] },
-  { name: "2 Timothy", aliases: ["2 timothy", "second timothy", "2 tim"] },
-  { name: "Titus" },
-  { name: "Philemon", aliases: ["philem", "philemon"] },
-  { name: "Hebrews", aliases: ["heb", "hebrews"] },
-  { name: "James", aliases: ["jam", "james"] },
-  { name: "1 Peter", aliases: ["1 peter", "first peter", "1 pet"] },
-  { name: "2 Peter", aliases: ["2 peter", "second peter", "2 pet"] },
-  { name: "1 John", aliases: ["1 john", "first john", "1 jn"] },
-  { name: "2 John", aliases: ["2 john", "second john", "2 jn"] },
-  { name: "3 John", aliases: ["3 john", "third john", "3 jn"] },
-  { name: "Jude" },
-  { name: "Revelation", aliases: ["rev", "revelation", "revelations"] },
-];
-
-const BOOKS: BookAlias[] = BASE_BOOKS.map(({ name, aliases }) => {
-  const baseAlias = name.toLowerCase();
-  const aliasSet = new Set<string>([baseAlias]);
-
-  if (aliases) {
-    aliases.forEach((alias) => aliasSet.add(alias.toLowerCase()));
-  }
-
-  if (/^[1-3]/.test(name)) {
-    const parts = name.split(" ");
-    const number = parts[0];
-    const rest = parts.slice(1).join(" ");
-    const ordinal = number === "1" ? "first" : number === "2" ? "second" : "third";
-    aliasSet.add(`${number} ${rest}`.toLowerCase());
-    aliasSet.add(`${ordinal} ${rest}`.toLowerCase());
-  }
-
-  return {
-    name,
-    aliases: Array.from(aliasSet).sort((a, b) => b.length - a.length),
-  };
-});
+const BOOKS: BookAliasEntry[] = BOOK_ALIASES;
 
 const NUMBER_WORDS: Record<string, number> = {
   zero: 0,
@@ -210,7 +120,7 @@ export const parseReferenceFromText = (transcript: string): ParsedReference => {
   const lower = normaliseText(original);
   const originalLower = original.toLowerCase();
 
-  let matchedBook: BookAlias | null = null;
+  let matchedBook: BookAliasEntry | null = null;
   let matchedAlias: string | null = null;
   let matchIndex = Number.POSITIVE_INFINITY;
 

--- a/lib/bible/verseRange.ts
+++ b/lib/bible/verseRange.ts
@@ -1,0 +1,30 @@
+export function formatVerseRange(start: number, end: number): string {
+  if (start === end) {
+    return String(start);
+  }
+  return `${start}-${end}`;
+}
+
+export function parseVerseRangeValue(
+  value: string,
+): { start: number; end: number } | null {
+  const normalized = value.trim();
+  if (!normalized) {
+    return null;
+  }
+  const match = normalized.match(/^(\d+)(?:\s*-\s*(\d+))?$/);
+  if (!match) {
+    return null;
+  }
+  const start = Number(match[1]);
+  const end = match[2] ? Number(match[2]) : start;
+  if (
+    !Number.isFinite(start) ||
+    !Number.isFinite(end) ||
+    start <= 0 ||
+    end < start
+  ) {
+    return null;
+  }
+  return { start, end };
+}

--- a/tests/filterBooks.test.mjs
+++ b/tests/filterBooks.test.mjs
@@ -1,0 +1,91 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { loadTsModule } from "./utils/load-ts-module.mjs";
+
+const loadFilter = async () => {
+  const mod = await loadTsModule("lib/bible/filterBooks.ts");
+  return {
+    filterBooks: mod.filterBooks,
+    filterComboboxOptions: mod.filterComboboxOptions,
+  };
+};
+
+const sampleBooks = [
+  {
+    id: "gen",
+    name: "Genesis",
+    abbreviation: "Gen",
+    chapters: 50,
+    order: 1,
+  },
+  {
+    id: "john",
+    name: "John",
+    abbreviation: "Jn",
+    chapters: 21,
+    order: 43,
+  },
+  {
+    id: "1cor",
+    name: "1 Corinthians",
+    abbreviation: "1 Cor",
+    chapters: 16,
+    order: 46,
+  },
+  {
+    id: "rev",
+    name: "Revelation",
+    abbreviation: "Rev",
+    chapters: 22,
+    order: 66,
+  },
+];
+
+describe("filterBooks", () => {
+  it("returns all books for an empty query", async () => {
+    const { filterBooks } = await loadFilter();
+    assert.equal(filterBooks(sampleBooks, "").length, sampleBooks.length);
+    assert.equal(filterBooks(sampleBooks, "   ").length, sampleBooks.length);
+  });
+
+  it("matches by name prefix and abbreviation", async () => {
+    const { filterBooks } = await loadFilter();
+    assert.deepEqual(
+      filterBooks(sampleBooks, "gen").map((book) => book.name),
+      ["Genesis"],
+    );
+    assert.deepEqual(
+      filterBooks(sampleBooks, "jn").map((book) => book.name),
+      ["John"],
+    );
+  });
+
+  it("matches numbered book aliases", async () => {
+    const { filterBooks } = await loadFilter();
+    assert.deepEqual(
+      filterBooks(sampleBooks, "1 cor").map((book) => book.name),
+      ["1 Corinthians"],
+    );
+    assert.deepEqual(
+      filterBooks(sampleBooks, "first corinthians").map((book) => book.name),
+      ["1 Corinthians"],
+    );
+  });
+});
+
+describe("filterComboboxOptions", () => {
+  it("filters by label and keywords", async () => {
+    const { filterComboboxOptions } = await loadFilter();
+    const options = [
+      { value: "1", label: "Chapter 1", keywords: ["1"] },
+      { value: "15", label: "Chapter 15", keywords: ["15"] },
+      { value: "50", label: "Chapter 50", keywords: ["50"] },
+    ];
+
+    assert.deepEqual(
+      filterComboboxOptions(options, "15").map((option) => option.value),
+      ["15"],
+    );
+  });
+});

--- a/tests/utils/load-ts-module.mjs
+++ b/tests/utils/load-ts-module.mjs
@@ -16,22 +16,93 @@ const COMPILER_OPTIONS = {
   esModuleInterop: true,
 };
 
-export const loadTsModule = async (relativePath) => {
-  const absolutePath = path.resolve(ROOT_DIR, relativePath);
-  const source = await readFile(absolutePath, "utf8");
+const IMPORT_RE =
+  /(?<=(?:^|\n)import\s+(?!type\b)[^"'`]*?\sfrom\s+)["'](@\/[^"']+|\.{1,2}\/[^"']+)["']/g;
 
-  const transpiled = ts.transpileModule(source, {
-    compilerOptions: COMPILER_OPTIONS,
-    fileName: path.basename(relativePath),
+const resolveImportPath = (fromFile, specifier) => {
+  if (specifier.startsWith("@/")) {
+    return path.resolve(ROOT_DIR, specifier.slice(2));
+  }
+  return path.resolve(path.dirname(fromFile), specifier);
+};
+
+const withTsExtension = (absolutePath) => {
+  if (absolutePath.endsWith(".ts") || absolutePath.endsWith(".tsx")) {
+    return absolutePath;
+  }
+  return `${absolutePath}.ts`;
+};
+
+/**
+ * Transpile a TS module and recursively rewrite local/@ imports to data URLs
+ * so node:test can load split modules without a bundler.
+ */
+export const loadTsModule = async (relativePath, cache = new Map()) => {
+  const loaded = await loadTsModuleEntry(relativePath, cache);
+  return loaded.module;
+};
+
+const loadTsModuleEntry = async (relativePath, cache) => {
+  const absolutePath = withTsExtension(path.resolve(ROOT_DIR, relativePath));
+
+  if (cache.has(absolutePath)) {
+    return cache.get(absolutePath);
+  }
+
+  let settle;
+  const pending = new Promise((resolve, reject) => {
+    settle = { resolve, reject };
   });
+  // Store the promise so concurrent loads share one build.
+  cache.set(absolutePath, pending);
 
-  const moduleUrl = new URL(
-    `data:text/javascript;base64,${Buffer.from(transpiled.outputText).toString(
-      "base64"
-    )}`
-  );
+  try {
+    let source = await readFile(absolutePath, "utf8");
+    source = source.replace(/^import\s+type\s+[^;]+;?\s*$/gm, "");
 
-  return import(moduleUrl.href, {
-    assert: { type: "javascript" },
-  });
+    const specifiers = [...source.matchAll(IMPORT_RE)].map((match) => match[1]);
+    const rewrittenSpecifiers = new Map();
+
+    for (const specifier of specifiers) {
+      const depAbsolute = withTsExtension(
+        resolveImportPath(absolutePath, specifier)
+      );
+      const depEntry = await loadTsModuleEntry(
+        path.relative(ROOT_DIR, depAbsolute),
+        cache
+      );
+      rewrittenSpecifiers.set(specifier, depEntry.moduleUrl);
+    }
+
+    let rewrittenSource = source;
+    for (const [specifier, moduleUrl] of rewrittenSpecifiers) {
+      rewrittenSource = rewrittenSource.replaceAll(
+        `"${specifier}"`,
+        `"${moduleUrl}"`
+      );
+      rewrittenSource = rewrittenSource.replaceAll(
+        `'${specifier}'`,
+        `"${moduleUrl}"`
+      );
+    }
+
+    const transpiled = ts.transpileModule(rewrittenSource, {
+      compilerOptions: COMPILER_OPTIONS,
+      fileName: path.basename(absolutePath),
+    });
+
+    const moduleUrl = `data:text/javascript;base64,${Buffer.from(
+      transpiled.outputText
+    ).toString("base64")}`;
+
+    const imported = await import(moduleUrl);
+    const entry = { module: imported, moduleUrl };
+    cache.set(absolutePath, entry);
+    settle.resolve(entry);
+    return entry;
+  } catch (error) {
+    cache.delete(absolutePath);
+    settle.reject(error);
+    throw error;
+  }
 };

--- a/tests/verseRangePicker.test.mjs
+++ b/tests/verseRangePicker.test.mjs
@@ -1,0 +1,28 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { loadTsModule } from "./utils/load-ts-module.mjs";
+
+const loadHelpers = async () => {
+  const mod = await loadTsModule("lib/bible/verseRange.ts");
+  return {
+    formatVerseRange: mod.formatVerseRange,
+    parseVerseRangeValue: mod.parseVerseRangeValue,
+  };
+};
+
+describe("verseRange helpers", () => {
+  it("formats single and ranged verses", async () => {
+    const { formatVerseRange } = await loadHelpers();
+    assert.equal(formatVerseRange(5, 5), "5");
+    assert.equal(formatVerseRange(1, 26), "1-26");
+  });
+
+  it("parses verse range strings", async () => {
+    const { parseVerseRangeValue } = await loadHelpers();
+    assert.deepEqual(parseVerseRangeValue("1-26"), { start: 1, end: 26 });
+    assert.deepEqual(parseVerseRangeValue("5"), { start: 5, end: 5 });
+    assert.equal(parseVerseRangeValue(""), null);
+    assert.equal(parseVerseRangeValue("nope"), null);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Follow-up UX pass on the scripture typeahead for admin Pre-Read create/edit.

### Changes
- Restyled `Combobox` to match admin form controls (warm borders, larger touch targets, branded option highlight)
- Replaced free-text verses with a **From / To** range picker; verse bounds load dynamically once book + chapter are selected
- Enlarged mobile buttons across the form, including publish status toggles and materials actions

### Test plan
- [ ] Book/chapter typeahead look correct on mobile + desktop
- [ ] Select book + chapter → verse From/To unlock with correct max
- [ ] Changing start clamps end when needed; range saves as `1-26` style
- [ ] Publish status / Cancel / Save / Add question buttons are larger on mobile

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6b08-f355-774b-a220-b958a42745b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6b08-f355-774b-a220-b958a42745b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

