### PR TITLE
Align Study/Reflections controls with admin; remove Reflections meta

### DIFF
--- a/app/(admin)/admin/pre-read/PreReadForm.module.css
+++ b/app/(admin)/admin/pre-read/PreReadForm.module.css
@@ -157,7 +157,8 @@
 
 .field :global(input),
 .field :global(textarea),
-.field :global(button[data-slot="select-trigger"]) {
+.field :global(button[data-slot="select-trigger"]),
+.field :global(button[role="combobox"]) {
   width: 100%;
   max-width: 100%;
   min-width: 0;
@@ -237,9 +238,13 @@ textarea.control {
 .statusToggles {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65rem;
+  gap: 0.75rem;
   min-width: 0;
   max-width: 100%;
+}
+
+.statusToggles :global(button) {
+  border-radius: 0.85rem;
 }
 
 .arrayGroup {
@@ -463,6 +468,25 @@ textarea.control {
   .toolbarActions :global(a),
   .toolbarActions :global(button) {
     flex: 1 1 calc(50% - 0.4rem);
+    min-height: 3.5rem;
+  }
+
+  .statusToggles {
+    gap: 0.75rem;
+  }
+
+  .statusToggles :global(button) {
+    flex: 1 1 100%;
+    min-height: 3.5rem;
+    font-size: 1.05rem;
+  }
+
+  .formShell :global(button:not([role="combobox"])) {
+    min-height: 3.5rem;
+  }
+
+  .formShell :global(button[role="combobox"]) {
+    min-height: 3.5rem;
   }
 
   .control {
@@ -470,7 +494,7 @@ textarea.control {
     width: 100%;
     max-width: 100%;
     min-width: 0 !important;
-    min-height: 3.15rem;
+    min-height: 3.5rem;
     font-size: 1.05rem;
     padding: 0.85rem 1rem;
   }
@@ -491,9 +515,15 @@ textarea.control {
   .actions :global(a),
   .actions :global(button) {
     width: 100%;
+    min-height: 3.5rem;
   }
 
   .section {
     padding: 1.1rem 1rem;
+  }
+
+  .materialsActions :global(button),
+  .materialsActions :global(label) {
+    min-height: 3.5rem;
   }
 }

--- a/app/(admin)/admin/pre-read/PreReadForm.module.css
+++ b/app/(admin)/admin/pre-read/PreReadForm.module.css
@@ -5,6 +5,14 @@
   max-width: 100%;
   min-width: 0;
   align-items: start;
+  overflow-x: clip;
+}
+
+.previewColumn {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow-x: clip;
 }
 
 @media (min-width: 1100px) {
@@ -15,8 +23,6 @@
   .previewColumn {
     position: sticky;
     top: 5.5rem;
-    min-width: 0;
-    max-width: 100%;
   }
 }
 

--- a/app/(admin)/admin/pre-read/PreReadForm.module.css
+++ b/app/(admin)/admin/pre-read/PreReadForm.module.css
@@ -205,7 +205,8 @@
 }
 
 button.control,
-.control[data-slot="select-trigger"] {
+.control[data-slot="select-trigger"],
+.control[role="combobox"] {
   display: flex;
   width: 100%;
   max-width: 100%;

--- a/app/(admin)/admin/pre-read/PreReadForm.tsx
+++ b/app/(admin)/admin/pre-read/PreReadForm.tsx
@@ -6,16 +6,11 @@ import { PlusCircle, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
+import { BookCombobox } from "@/components/bible/BookCombobox";
 import { Button } from "@/components/ui/button";
+import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import {
   createStudyLinkMaterial,
@@ -733,49 +728,39 @@ export default function PreReadForm({
           <div className={styles.fieldGrid}>
             <div className={styles.field}>
               <Label className={styles.label}>Book</Label>
-              <Select
+              <BookCombobox
+                books={books}
                 value={form.book || undefined}
+                valueKey="name"
                 onValueChange={handleBookSelect}
                 disabled={isLoadingBooks}
-              >
-                <SelectTrigger className={`${styles.control} w-full min-w-0 max-w-full`}>
-                  <SelectValue
-                    placeholder={
-                      isLoadingBooks ? "Loading books…" : "Choose a book"
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {books.map((book) => (
-                    <SelectItem key={book.id} value={book.name}>
-                      {book.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                placeholder={
+                  isLoadingBooks ? "Loading books…" : "Choose a book"
+                }
+                searchPlaceholder="Type a book (e.g. gen, john)…"
+                triggerClassName={`${styles.control} w-full min-w-0 max-w-full`}
+                aria-label="Bible book"
+              />
             </div>
             <div className={styles.field}>
               <Label className={styles.label}>Chapter</Label>
-              <Select
+              <Combobox
+                options={chapterOptions.map((chapter) => ({
+                  value: String(chapter),
+                  label: `Chapter ${chapter}`,
+                  keywords: [String(chapter)],
+                }))}
                 value={form.chapter || undefined}
                 onValueChange={handleChapterSelect}
                 disabled={!selectedBook}
-              >
-                <SelectTrigger className={`${styles.control} w-full min-w-0 max-w-full`}>
-                  <SelectValue
-                    placeholder={
-                      selectedBook ? "Choose a chapter" : "Select a book first"
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {chapterOptions.map((chapter) => (
-                    <SelectItem key={chapter} value={String(chapter)}>
-                      Chapter {chapter}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                placeholder={
+                  selectedBook ? "Choose a chapter" : "Select a book first"
+                }
+                searchPlaceholder="Type a chapter number…"
+                emptyMessage="No chapters match."
+                triggerClassName={`${styles.control} w-full min-w-0 max-w-full`}
+                aria-label="Chapter"
+              />
             </div>
             <div className={styles.field}>
               <Label htmlFor="verses_range" className={styles.label}>

--- a/app/(admin)/admin/pre-read/PreReadForm.tsx
+++ b/app/(admin)/admin/pre-read/PreReadForm.tsx
@@ -35,6 +35,7 @@ import {
 import styles from "./PreReadForm.module.css";
 import { StudyHubPreview } from "./StudyHubPreview";
 import { StudyMaterialsEditor } from "./StudyMaterialsEditor";
+import { WeekPicker } from "./WeekPicker";
 
 /** Bigger tap targets on mobile; comfortable padded size from md up. */
 const btnSize =
@@ -207,10 +208,10 @@ export default function PreReadForm({
       cancelled = true;
     };
   }, [mode, initialData?.id]);
-  const resetWeekStart = () => {
+  const handleWeekChange = (weekStart: string) => {
     setForm((prev) => ({
       ...prev,
-      weekStart: getCurrentWeekStartInput(),
+      weekStart: startOfWeek(new Date(`${weekStart}T12:00:00`)),
     }));
   };
 
@@ -683,38 +684,21 @@ export default function PreReadForm({
                 required
               />
             </div>
-            <div className={styles.field}>
-              <Label htmlFor="week_start" className={styles.label}>
-                Week of
-              </Label>
-              <Input
+            <div className={`${styles.field} ${styles.fieldWide}`}>
+              <Label className={styles.label}>Week of</Label>
+              <WeekPicker
                 id="week_start"
-                type="date"
-                className={`${styles.control} w-full min-w-0 max-w-full`}
                 value={form.weekStart}
-                onChange={(event) =>
-                  handleFieldChange("weekStart", event.target.value)
-                }
-                required
+                onValueChange={handleWeekChange}
               />
               <p className={styles.helper}>
-                Saved as the Monday of that week
+                Members see this study during the Monday–Sunday block shown
+                above
                 {form.weekStart
-                  ? ` (${formatWeekLabel(
-                      startOfWeek(new Date(`${form.weekStart}T12:00:00`)),
-                    )})`
+                  ? ` (${formatWeekLabel(form.weekStart)})`
                   : ""}
                 .
               </p>
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                className={`mt-1 w-fit ${btnSize}`}
-                onClick={resetWeekStart}
-              >
-                Use this week
-              </Button>
             </div>
           </div>
         </section>

--- a/app/(admin)/admin/pre-read/PreReadForm.tsx
+++ b/app/(admin)/admin/pre-read/PreReadForm.tsx
@@ -7,11 +7,13 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { BookCombobox } from "@/components/bible/BookCombobox";
+import { VerseRangePicker } from "@/components/bible/VerseRangePicker";
 import { Button } from "@/components/ui/button";
 import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { parseVerseRangeValue } from "@/lib/bible/verseRange";
 import {
   createStudyLinkMaterial,
   deleteStudyMaterial,
@@ -36,14 +38,14 @@ import { StudyMaterialsEditor } from "./StudyMaterialsEditor";
 
 /** Bigger tap targets on mobile; comfortable padded size from md up. */
 const btnSize =
-  "h-12 px-5 text-base md:h-10 md:px-5 md:text-sm";
-const btnIconSize = "size-11 md:size-9";
+  "h-14 min-h-14 px-6 text-base md:h-10 md:min-h-10 md:px-5 md:text-sm";
+const btnIconSize = "size-12 md:size-9";
 const btnSecondary =
-  "h-12 min-w-[8.5rem] px-6 text-base md:h-11 md:min-w-[7.5rem] md:px-6 md:text-sm border-[#e0c4b6] bg-white text-[#1a1a1a] hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26]";
+  "h-14 min-h-14 min-w-[8.5rem] px-6 text-base md:h-11 md:min-h-11 md:min-w-[7.5rem] md:px-6 md:text-sm border-[#e0c4b6] bg-white text-[#1a1a1a] hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26]";
 const btnPrimary =
-  "h-12 min-w-[8.5rem] px-6 text-base md:h-11 md:min-w-[7.5rem] md:px-6 md:text-sm border-0 bg-gradient-to-br from-[#d91f26] to-[#f28c00] text-white font-bold shadow-[0_10px_24px_color-mix(in_oklab,#d91f26_28%,transparent)] hover:brightness-105 hover:text-white";
+  "h-14 min-h-14 min-w-[8.5rem] px-6 text-base md:h-11 md:min-h-11 md:min-w-[7.5rem] md:px-6 md:text-sm border-0 bg-gradient-to-br from-[#d91f26] to-[#f28c00] text-white font-bold shadow-[0_10px_24px_color-mix(in_oklab,#d91f26_28%,transparent)] hover:brightness-105 hover:text-white";
 const btnStatus =
-  "h-12 flex-1 basis-28 min-w-0 px-4 text-base md:h-10 md:px-5 md:text-sm hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26]";
+  "h-14 min-h-14 flex-1 basis-[calc(50%-0.35rem)] min-w-0 px-4 text-base font-semibold md:h-11 md:min-h-11 md:basis-28 md:px-5 md:text-sm hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26]";
 
 type PreReadFormProps = {
   mode: "create" | "edit";
@@ -127,6 +129,10 @@ export default function PreReadForm({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [books, setBooks] = useState<BibleBookSummary[]>([]);
   const [isLoadingBooks, setIsLoadingBooks] = useState(true);
+  const [chapterVerseCount, setChapterVerseCount] = useState<number | null>(
+    null,
+  );
+  const [isLoadingVerses, setIsLoadingVerses] = useState(false);
   const [versesManuallyEdited, setVersesManuallyEdited] = useState(
     Boolean(initialData?.verses_range && initialData.verses_range.length > 0)
   );
@@ -280,16 +286,17 @@ export default function PreReadForm({
       !Number.isFinite(currentChapter) ||
       currentChapter < CHAPTER_MIN
     ) {
+      setChapterVerseCount(null);
+      setIsLoadingVerses(false);
       return;
     }
-    if (versesEditedRef.current) {
-      return;
-    }
+
     let active = true;
     const controller = new AbortController();
 
     const hydrateVerses = async () => {
       try {
+        setIsLoadingVerses(true);
         const response = await fetch(
           CHAPTER_ENDPOINT(currentBook, currentChapter),
           {
@@ -303,7 +310,11 @@ export default function PreReadForm({
         const verseCount = Array.isArray(payload.verses)
           ? payload.verses.length
           : 0;
-        if (!active || verseCount === 0) {
+        if (!active) {
+          return;
+        }
+        setChapterVerseCount(verseCount > 0 ? verseCount : null);
+        if (verseCount === 0 || versesEditedRef.current) {
           return;
         }
         setForm((prev) => {
@@ -322,6 +333,11 @@ export default function PreReadForm({
       } catch (error) {
         if (active && (error as Error).name !== "AbortError") {
           console.error("Failed to auto-fill verse range", error);
+          setChapterVerseCount(null);
+        }
+      } finally {
+        if (active) {
+          setIsLoadingVerses(false);
         }
       }
     };
@@ -341,6 +357,7 @@ export default function PreReadForm({
       chapter: "",
       versesRange: "",
     }));
+    setChapterVerseCount(null);
     setVersesManuallyEdited(false);
   };
 
@@ -348,7 +365,9 @@ export default function PreReadForm({
     setForm((prev) => ({
       ...prev,
       chapter: value,
+      versesRange: "",
     }));
+    setChapterVerseCount(null);
     setVersesManuallyEdited(false);
   };
 
@@ -420,27 +439,7 @@ export default function PreReadForm({
     }
   };
 
-  const parseVerseRange = (value: string) => {
-    const normalized = value.trim();
-    if (!normalized) {
-      return null;
-    }
-    const match = normalized.match(/^(\d+)(?:\s*-\s*(\d+))?$/);
-    if (!match) {
-      return null;
-    }
-    const start = Number(match[1]);
-    const end = match[2] ? Number(match[2]) : start;
-    if (
-      !Number.isFinite(start) ||
-      !Number.isFinite(end) ||
-      start <= 0 ||
-      end < start
-    ) {
-      return null;
-    }
-    return { start, end };
-  };
+  const parseVerseRange = parseVerseRangeValue;
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -762,19 +761,21 @@ export default function PreReadForm({
                 aria-label="Chapter"
               />
             </div>
-            <div className={styles.field}>
-              <Label htmlFor="verses_range" className={styles.label}>
-                Verses (optional)
-              </Label>
-              <Input
-                id="verses_range"
-                className={`${styles.control} w-full min-w-0 max-w-full`}
+            <div className={`${styles.field} ${styles.fieldWide}`}>
+              <Label className={styles.label}>Verses</Label>
+              <VerseRangePicker
+                verseCount={chapterVerseCount}
                 value={form.versesRange}
-                onChange={(event) => handleVersesChange(event.target.value)}
-                placeholder="1-26"
+                onValueChange={handleVersesChange}
+                disabled={isLoadingVerses}
+                triggerClassName={`${styles.control} w-full min-w-0 max-w-full`}
               />
               <p className={styles.helper}>
-                Leave blank for the full chapter.
+                {isLoadingVerses
+                  ? "Loading verse bounds…"
+                  : chapterVerseCount
+                    ? `Chapter has ${chapterVerseCount} verses. Defaults to the full chapter.`
+                    : "Pick a book and chapter to unlock verse bounds."}
               </p>
             </div>
             <div className={styles.field}>

--- a/app/(admin)/admin/pre-read/StudyHubPreview.module.css
+++ b/app/(admin)/admin/pre-read/StudyHubPreview.module.css
@@ -2,7 +2,10 @@
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
+  width: 100%;
+  max-width: 100%;
   min-width: 0;
+  overflow-x: clip;
 }
 
 .header {
@@ -10,6 +13,13 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 0.75rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.header > div {
+  min-width: 0;
+  flex: 1;
 }
 
 .eyebrow {
@@ -26,10 +36,12 @@
   font-size: 1.05rem;
   font-weight: 700;
   color: #1a1a1a;
+  overflow-wrap: anywhere;
 }
 
 .status {
   flex-shrink: 0;
+  max-width: 40%;
   padding: 0.3rem 0.6rem;
   border-radius: 999px;
   background: #ffe8dc;
@@ -38,9 +50,15 @@
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
+  text-align: center;
+  overflow-wrap: anywhere;
 }
 
 .phone {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   border-radius: 1.25rem;
   border: 1px solid #e8cfc4;
   background: #fff5f0;
@@ -50,8 +68,9 @@
   flex-direction: column;
   gap: 0.85rem;
   max-height: min(72vh, 780px);
+  overflow-x: clip;
   overflow-y: auto;
-  min-width: 0;
+  overscroll-behavior: contain;
 }
 
 .topBar {
@@ -59,24 +78,29 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
+  min-width: 0;
 }
 
 .back {
   font-size: 0.85rem;
   font-weight: 650;
   color: #d91f26;
+  min-width: 0;
 }
 
 .brand {
   font-size: 0.9rem;
   font-weight: 800;
   color: #d91f26;
+  flex-shrink: 0;
 }
 
 .hero {
   display: flex;
   flex-direction: column;
   gap: 0.45rem;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .heroEyebrow {
@@ -86,6 +110,7 @@
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: #4a4a4a;
+  overflow-wrap: anywhere;
 }
 
 .heroTitle {
@@ -95,6 +120,7 @@
   line-height: 1.2;
   color: #1a1a1a;
   overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .scriptureRow {
@@ -102,13 +128,19 @@
   flex-wrap: wrap;
   align-items: center;
   gap: 0.5rem 0.75rem;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .scriptureRef {
   margin: 0;
+  min-width: 0;
+  max-width: 100%;
   font-size: 0.95rem;
   font-weight: 700;
   color: #d91f26;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .heroLink {
@@ -118,6 +150,7 @@
   font-size: 0.8rem;
   font-weight: 650;
   color: #d91f26;
+  flex-shrink: 0;
 }
 
 .heroLinkIcon {
@@ -128,10 +161,15 @@
 .card,
 .cardMuted,
 .memory {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   border-radius: 0.85rem;
   border: 1px solid #e8cfc4;
   padding: 0.85rem 0.9rem;
   background: #ffffff;
+  overflow-wrap: anywhere;
 }
 
 .cardMuted {
@@ -161,6 +199,8 @@
   line-height: 1.55;
   color: #1a1a1a;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .materials {
@@ -170,6 +210,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .materialCard {
@@ -181,6 +223,7 @@
   border: 1px solid #e8cfc4;
   background: #fff8f4;
   min-width: 0;
+  max-width: 100%;
 }
 
 .materialIcon {
@@ -244,6 +287,8 @@
   font-weight: 600;
   line-height: 1.4;
   color: #1a1a1a;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .memoryRef {
@@ -251,6 +296,8 @@
   font-size: 0.8rem;
   font-weight: 650;
   color: #d91f26;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .questions {
@@ -261,6 +308,8 @@
   gap: 0.4rem;
   font-size: 0.85rem;
   color: #1a1a1a;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .pollQ {
@@ -268,6 +317,8 @@
   font-size: 0.9rem;
   font-weight: 650;
   color: #1a1a1a;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .pollOptions {
@@ -277,15 +328,21 @@
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+  min-width: 0;
 }
 
 .pollOptions li {
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
   padding: 0.5rem 0.65rem;
   border-radius: 0.55rem;
   border: 1px solid #e8cfc4;
   background: #ffffff;
   font-size: 0.85rem;
   color: #1a1a1a;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .empty {
@@ -295,6 +352,8 @@
   text-align: center;
   gap: 0.55rem;
   padding: 2.5rem 1rem;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .emptyIcon {
@@ -318,6 +377,7 @@
   font-size: 1.05rem;
   font-weight: 750;
   color: #1a1a1a;
+  overflow-wrap: anywhere;
 }
 
 .emptyText {
@@ -326,4 +386,11 @@
   line-height: 1.45;
   color: #4a4a4a;
   max-width: 16rem;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 1099px) {
+  .phone {
+    max-height: min(64vh, 640px);
+  }
 }

--- a/app/(admin)/admin/pre-read/StudyMaterialsEditor.tsx
+++ b/app/(admin)/admin/pre-read/StudyMaterialsEditor.tsx
@@ -16,13 +16,13 @@ import {
 } from "./draft-materials";
 import styles from "./PreReadForm.module.css";
 
-const btnIconSize = "size-11 md:size-9";
+const btnIconSize = "size-12 md:size-9";
 const btnSecondary =
-  "h-12 min-w-[8.5rem] px-6 text-base md:h-11 md:min-w-[7.5rem] md:px-6 md:text-sm border-[#e0c4b6] bg-white text-[#1a1a1a] hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26]";
+  "h-14 min-h-14 min-w-[8.5rem] px-6 text-base md:h-11 md:min-h-11 md:min-w-[7.5rem] md:px-6 md:text-sm border-[#e0c4b6] bg-white text-[#1a1a1a] hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26]";
 const btnPrimary =
-  "h-12 min-w-[8.5rem] px-6 text-base md:h-11 md:min-w-[7.5rem] md:px-6 md:text-sm border-0 bg-gradient-to-br from-[#d91f26] to-[#f28c00] text-white font-bold shadow-[0_10px_24px_color-mix(in_oklab,#d91f26_28%,transparent)] hover:brightness-105 hover:text-white";
+  "h-14 min-h-14 min-w-[8.5rem] px-6 text-base md:h-11 md:min-h-11 md:min-w-[7.5rem] md:px-6 md:text-sm border-0 bg-gradient-to-br from-[#d91f26] to-[#f28c00] text-white font-bold shadow-[0_10px_24px_color-mix(in_oklab,#d91f26_28%,transparent)] hover:brightness-105 hover:text-white";
 const uploadBtn =
-  "relative inline-flex h-12 min-w-[8.5rem] cursor-pointer items-center justify-center gap-2 overflow-hidden rounded-md bg-gradient-to-br from-[#d91f26] to-[#f28c00] px-6 text-base font-bold text-white hover:brightness-105 md:h-11 md:min-w-[7.5rem] md:px-6 md:text-sm";
+  "relative inline-flex h-14 min-h-14 min-w-[8.5rem] cursor-pointer items-center justify-center gap-2 overflow-hidden rounded-md bg-gradient-to-br from-[#d91f26] to-[#f28c00] px-6 text-base font-bold text-white hover:brightness-105 md:h-11 md:min-h-11 md:min-w-[7.5rem] md:px-6 md:text-sm";
 
 type StudyMaterialsEditorProps = {
   materials: DraftMaterial[];

--- a/app/(admin)/admin/pre-read/WeekPicker.module.css
+++ b/app/(admin)/admin/pre-read/WeekPicker.module.css
@@ -1,0 +1,396 @@
+.root {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1.5px solid #e0c4b6;
+  background: linear-gradient(
+    160deg,
+    color-mix(in oklab, #fff8f4 88%, #ffffff),
+    #ffffff
+  );
+  box-shadow: 0 8px 22px color-mix(in oklab, #d91f26 6%, transparent);
+}
+
+.cardTop {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.rangeBlock {
+  min-width: 0;
+  flex: 1;
+}
+
+.rangeEyebrow {
+  margin: 0;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #d91f26;
+}
+
+.rangeLabel {
+  margin: 0.25rem 0 0;
+  font-size: 1.15rem;
+  font-weight: 750;
+  line-height: 1.25;
+  color: #1a1a1a;
+  overflow-wrap: anywhere;
+}
+
+.rangeMeta {
+  margin: 0.2rem 0 0;
+  font-size: 0.8rem;
+  color: #6b5a52;
+}
+
+.badge,
+.badgeButton {
+  flex-shrink: 0;
+  border-radius: 999px;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.badge {
+  background: color-mix(in oklab, #d91f26 12%, #ffe8dc);
+  color: #d91f26;
+}
+
+.badgeButton {
+  border: 1.5px solid #e0c4b6;
+  background: #ffffff;
+  color: #1a1a1a;
+  cursor: pointer;
+  transition:
+    border-color 150ms ease,
+    background 150ms ease,
+    color 150ms ease;
+}
+
+.badgeButton:hover:not(:disabled) {
+  border-color: #d91f26;
+  background: color-mix(in oklab, #d91f26 8%, #ffffff);
+  color: #d91f26;
+}
+
+.badgeButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.navRow {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.45rem;
+  align-items: center;
+  min-width: 0;
+}
+
+.navButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.75rem;
+  border: 1.5px solid #e0c4b6;
+  background: #ffffff;
+  color: #1a1a1a;
+  cursor: pointer;
+  transition:
+    border-color 150ms ease,
+    background 150ms ease,
+    color 150ms ease;
+}
+
+.navButton svg {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.navButton:hover:not(:disabled) {
+  border-color: #d91f26;
+  color: #d91f26;
+  background: color-mix(in oklab, #d91f26 8%, #ffffff);
+}
+
+.navButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.dayStrip {
+  list-style: none;
+  margin: 0;
+  padding: 0.35rem;
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.2rem;
+  min-width: 0;
+  border-radius: 0.85rem;
+  background: #fff5f0;
+  border: 1px solid #f0ddd4;
+}
+
+.dayCell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  min-width: 0;
+  padding: 0.45rem 0.15rem;
+  border-radius: 0.6rem;
+}
+
+.dayCell[data-today] {
+  background: color-mix(in oklab, #d91f26 12%, #ffffff);
+  box-shadow: inset 0 0 0 1.5px color-mix(in oklab, #d91f26 35%, transparent);
+}
+
+.dayName {
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6b5a52;
+}
+
+.dayNumber {
+  font-size: 0.95rem;
+  font-weight: 750;
+  color: #1a1a1a;
+  line-height: 1;
+}
+
+.dayCell[data-today] .dayNumber {
+  color: #d91f26;
+}
+
+.calendarTrigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 100%;
+  min-height: 3.25rem;
+  border-radius: 0.85rem;
+  border: 1.5px solid #e0c4b6;
+  background: #ffffff;
+  color: #1a1a1a;
+  font-size: 0.95rem;
+  font-weight: 650;
+  cursor: pointer;
+  transition:
+    border-color 150ms ease,
+    background 150ms ease,
+    color 150ms ease;
+}
+
+.calendarTrigger:hover:not(:disabled) {
+  border-color: #d91f26;
+  background: color-mix(in oklab, #d91f26 8%, #ffffff);
+  color: #d91f26;
+}
+
+.calendarTrigger:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.calendarIcon {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.popover {
+  width: min(calc(100vw - 2rem), 22rem);
+  padding: 0.85rem;
+  border-radius: 1rem;
+  border: 1.5px solid #e8cfc4;
+  background: #ffffff;
+  box-shadow:
+    0 18px 40px color-mix(in oklab, #1a1a1a 12%, transparent),
+    0 2px 8px color-mix(in oklab, #d91f26 8%, transparent);
+}
+
+.monthHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.monthTitle {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 750;
+  color: #1a1a1a;
+}
+
+.monthNav {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 0.7rem;
+  border: 1.5px solid #e0c4b6;
+  background: #fff8f4;
+  color: #1a1a1a;
+  cursor: pointer;
+}
+
+.monthNav svg {
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
+.monthNav:hover {
+  border-color: #d91f26;
+  color: #d91f26;
+}
+
+.calendarHint {
+  margin: 0.65rem 0 0.55rem;
+  font-size: 0.78rem;
+  color: #6b5a52;
+  text-align: center;
+}
+
+.weekdayRow {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.15rem;
+  margin-bottom: 0.25rem;
+  text-align: center;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6b5a52;
+}
+
+.monthGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.weekRow {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.1rem;
+  border-radius: 0.65rem;
+  padding: 0.1rem;
+  transition: background 120ms ease;
+}
+
+.weekRow[data-hovered] {
+  background: color-mix(in oklab, #d91f26 8%, #fff5f0);
+}
+
+.weekRow[data-selected] {
+  background: color-mix(in oklab, #d91f26 14%, #ffe8dc);
+  box-shadow: inset 0 0 0 1.5px color-mix(in oklab, #d91f26 40%, transparent);
+}
+
+.weekRow[data-current]:not([data-selected]) {
+  box-shadow: inset 0 0 0 1.5px color-mix(in oklab, #f28c00 45%, transparent);
+}
+
+.dayButton {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  min-height: 2.35rem;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 650;
+  color: #1a1a1a;
+  cursor: pointer;
+}
+
+.dayButton[data-outside] {
+  color: #b5a49b;
+  font-weight: 500;
+}
+
+.dayButton[data-today] {
+  color: #d91f26;
+  font-weight: 800;
+}
+
+.dayButton:hover,
+.dayButton:focus-visible {
+  outline: none;
+  background: color-mix(in oklab, #d91f26 10%, transparent);
+}
+
+.todayButton {
+  margin-top: 0.7rem;
+  width: 100%;
+  min-height: 2.75rem;
+  border-radius: 0.75rem;
+  border: 1.5px solid #e0c4b6;
+  background: #fff8f4;
+  color: #1a1a1a;
+  font-size: 0.9rem;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.todayButton:hover {
+  border-color: #d91f26;
+  color: #d91f26;
+  background: color-mix(in oklab, #d91f26 8%, #ffffff);
+}
+
+@media (min-width: 720px) {
+  .rangeLabel {
+    font-size: 1.25rem;
+  }
+
+  .navButton {
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+
+  .calendarTrigger {
+    min-height: 2.85rem;
+  }
+}
+
+@media (max-width: 419px) {
+  .dayName {
+    font-size: 0.55rem;
+  }
+
+  .dayNumber {
+    font-size: 0.85rem;
+  }
+
+  .navButton {
+    width: 2.4rem;
+    height: 2.4rem;
+  }
+}

--- a/app/(admin)/admin/pre-read/WeekPicker.tsx
+++ b/app/(admin)/admin/pre-read/WeekPicker.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { CalendarDays, ChevronLeft, ChevronRight } from "lucide-react";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  buildMonthWeeks,
+  daysOfWeek,
+  formatWeekRangeDetailed,
+  isCurrentWeek,
+  shiftMonth,
+  shiftWeek,
+  startOfMonth,
+  startOfWeek,
+  todayYmd,
+} from "@/lib/study/week";
+
+import styles from "./WeekPicker.module.css";
+
+export type WeekPickerProps = {
+  value: string;
+  onValueChange: (weekStart: string) => void;
+  id?: string;
+  disabled?: boolean;
+};
+
+const WEEKDAY_HEADERS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+export function WeekPicker({
+  value,
+  onValueChange,
+  id,
+  disabled = false,
+}: WeekPickerProps) {
+  const selectedWeek = value || startOfWeek(new Date());
+  const current = isCurrentWeek(selectedWeek);
+  const days = useMemo(() => daysOfWeek(selectedWeek), [selectedWeek]);
+  const rangeLabel = formatWeekRangeDetailed(selectedWeek);
+  const today = useMemo(() => todayYmd(), []);
+
+  const [calendarOpen, setCalendarOpen] = useState(false);
+  const [visibleMonth, setVisibleMonth] = useState(() =>
+    startOfMonth(selectedWeek),
+  );
+  const [hoveredWeek, setHoveredWeek] = useState<string | null>(null);
+
+  const monthWeeks = useMemo(
+    () => buildMonthWeeks(visibleMonth),
+    [visibleMonth],
+  );
+
+  const monthTitle = useMemo(() => {
+    const date = new Date(`${visibleMonth}T12:00:00`);
+    return new Intl.DateTimeFormat("en-US", {
+      month: "long",
+      year: "numeric",
+    }).format(date);
+  }, [visibleMonth]);
+
+  const selectWeek = (weekStart: string) => {
+    onValueChange(weekStart);
+    setVisibleMonth(startOfMonth(weekStart));
+    setCalendarOpen(false);
+    setHoveredWeek(null);
+  };
+
+  const goToCurrentWeek = () => {
+    selectWeek(startOfWeek(new Date()));
+  };
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.card}>
+        <div className={styles.cardTop}>
+          <div className={styles.rangeBlock}>
+            <p className={styles.rangeEyebrow}>Study week</p>
+            <p className={styles.rangeLabel} id={id}>
+              {rangeLabel}
+            </p>
+            <p className={styles.rangeMeta}>Monday – Sunday</p>
+          </div>
+          {current ? (
+            <span className={styles.badge}>This week</span>
+          ) : (
+            <button
+              type="button"
+              className={styles.badgeButton}
+              onClick={goToCurrentWeek}
+              disabled={disabled}
+            >
+              Jump to this week
+            </button>
+          )}
+        </div>
+
+        <div className={styles.navRow}>
+          <button
+            type="button"
+            className={styles.navButton}
+            aria-label="Previous week"
+            disabled={disabled}
+            onClick={() => onValueChange(shiftWeek(selectedWeek, -1))}
+          >
+            <ChevronLeft aria-hidden="true" />
+          </button>
+
+          <ol className={styles.dayStrip} aria-label={`Week of ${rangeLabel}`}>
+            {days.map((day) => (
+              <li
+                key={day.ymd}
+                className={styles.dayCell}
+                data-today={day.isToday ? "" : undefined}
+              >
+                <span className={styles.dayName}>{day.weekdayShort}</span>
+                <span className={styles.dayNumber}>{day.dayOfMonth}</span>
+              </li>
+            ))}
+          </ol>
+
+          <button
+            type="button"
+            className={styles.navButton}
+            aria-label="Next week"
+            disabled={disabled}
+            onClick={() => onValueChange(shiftWeek(selectedWeek, 1))}
+          >
+            <ChevronRight aria-hidden="true" />
+          </button>
+        </div>
+
+        <Popover
+          open={calendarOpen}
+          onOpenChange={(open) => {
+            setCalendarOpen(open);
+            if (open) {
+              setVisibleMonth(startOfMonth(selectedWeek));
+              setHoveredWeek(null);
+            }
+          }}
+        >
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className={styles.calendarTrigger}
+              disabled={disabled}
+              aria-label="Choose another week"
+            >
+              <CalendarDays className={styles.calendarIcon} aria-hidden="true" />
+              Choose another week
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            sideOffset={8}
+            className={`w-[min(calc(100vw-2rem),22rem)] border-0 bg-transparent p-0 shadow-none ${styles.popover}`}
+            onOpenAutoFocus={(event) => event.preventDefault()}
+          >
+            <div className={styles.monthHeader}>
+              <button
+                type="button"
+                className={styles.monthNav}
+                aria-label="Previous month"
+                onClick={() => setVisibleMonth((month) => shiftMonth(month, -1))}
+              >
+                <ChevronLeft aria-hidden="true" />
+              </button>
+              <p className={styles.monthTitle}>{monthTitle}</p>
+              <button
+                type="button"
+                className={styles.monthNav}
+                aria-label="Next month"
+                onClick={() => setVisibleMonth((month) => shiftMonth(month, 1))}
+              >
+                <ChevronRight aria-hidden="true" />
+              </button>
+            </div>
+
+            <p className={styles.calendarHint}>
+              Tap any day to select that whole week
+            </p>
+
+            <div className={styles.weekdayRow} aria-hidden="true">
+              {WEEKDAY_HEADERS.map((label) => (
+                <span key={label}>{label}</span>
+              ))}
+            </div>
+
+            <div className={styles.monthGrid} role="grid" aria-label={monthTitle}>
+              {monthWeeks.map((week) => {
+                const weekStart = week[0]?.weekStart ?? "";
+                const isSelected = weekStart === selectedWeek;
+                const isHovered = hoveredWeek === weekStart;
+                const isThisWeek = isCurrentWeek(weekStart);
+                return (
+                  <div
+                    key={weekStart}
+                    role="row"
+                    className={styles.weekRow}
+                    data-selected={isSelected ? "" : undefined}
+                    data-hovered={isHovered && !isSelected ? "" : undefined}
+                    data-current={isThisWeek ? "" : undefined}
+                    onMouseEnter={() => setHoveredWeek(weekStart)}
+                    onMouseLeave={() => setHoveredWeek(null)}
+                  >
+                    {week.map((cell) => (
+                      <button
+                        key={cell.ymd}
+                        type="button"
+                        role="gridcell"
+                        className={styles.dayButton}
+                        data-outside={cell.inMonth ? undefined : ""}
+                        data-today={cell.ymd === today ? "" : undefined}
+                        aria-label={`Select week of ${formatWeekRangeDetailed(weekStart)}`}
+                        aria-selected={isSelected}
+                        onClick={() => selectWeek(weekStart)}
+                        onFocus={() => setHoveredWeek(weekStart)}
+                      >
+                        {cell.dayOfMonth}
+                      </button>
+                    ))}
+                  </div>
+                );
+              })}
+            </div>
+
+            <button
+              type="button"
+              className={styles.todayButton}
+              onClick={goToCurrentWeek}
+            >
+              Use this week
+            </button>
+          </PopoverContent>
+        </Popover>
+      </div>
+    </div>
+  );
+}

--- a/components/NotesScreen.module.css
+++ b/components/NotesScreen.module.css
@@ -45,81 +45,14 @@
 .headerTitle {
   margin: 0;
   font-size: 1.35rem;
-  font-weight: 600;
-  color: var(--primary);
-}
-
-.headerMeta {
-  margin: 0;
-  font-size: 0.8rem;
-  color: var(--muted-foreground);
-}
-
-.addButton {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background-color: var(--primary);
-  color: var(--primary-foreground);
-  transition: background-color 0.2s ease, transform 0.2s ease;
-  height: auto;
-  min-height: 48px;
-  padding: 0.7rem 1.3rem;
-  font-size: 0.95rem;
-  border-radius: calc(var(--radius) - 0.15rem);
-}
-
-.addButton:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.addButton:not(:disabled):hover {
-  background-color: color-mix(in oklab, var(--primary) 90%, transparent);
-  transform: translateY(-1px);
+  font-weight: 700;
+  color: #d91f26;
 }
 
 .addButtonIcon {
   width: 18px;
   height: 18px;
   margin-right: 6px;
-}
-
-.statsRow {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 14px;
-}
-
-.statCard {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 14px;
-  border-radius: 16px;
-  border: 1px solid color-mix(in oklab, var(--border) 50%, transparent);
-  background: var(--surface-gradient-soft);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
-}
-
-.statLabel {
-  margin: 0;
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: color-mix(in oklab, var(--muted-foreground) 90%, transparent);
-}
-
-.statValue {
-  font-size: 1.2rem;
-  font-weight: 600;
-  color: var(--foreground);
-}
-
-.statContext {
-  margin: 0;
-  font-size: 0.75rem;
-  color: color-mix(in oklab, var(--muted-foreground) 80%, transparent);
 }
 
 .searchWrap {
@@ -133,18 +66,13 @@
   width: 18px;
   height: 18px;
   transform: translateY(-50%);
-  color: var(--muted-foreground);
+  color: #8a7268;
   pointer-events: none;
+  z-index: 1;
 }
 
 .searchInput {
-  padding-left: 40px;
-  background-color: var(--input-background);
-  border: 1px solid var(--border);
-  border-color: color-mix(in oklab, var(--border) 55%, transparent);
-  width: 100%;
-  max-width: 100%;
-  box-sizing: border-box;
+  padding-left: 2.75rem;
 }
 
 .listArea {
@@ -452,14 +380,6 @@
   color: color-mix(in oklab, var(--muted-foreground) 85%, transparent);
 }
 
-.selectTrigger,
-.input,
-.textarea {
-  background-color: var(--input-background);
-  border: 1px solid var(--border);
-  border-color: color-mix(in oklab, var(--border) 55%, transparent);
-}
-
 .textarea {
   min-height: 150px;
   resize: vertical;
@@ -495,22 +415,6 @@
 
 .saveButton {
   width: 100%;
-  background-color: var(--primary);
-  color: var(--primary-foreground);
-  transition: background-color 0.2s ease, transform 0.2s ease;
-  padding-inline: 1.8rem;
-  height: 48px;
-  font-size: 1rem;
-}
-
-.saveButton:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.saveButton:not(:disabled):hover {
-  background-color: color-mix(in oklab, var(--primary) 90%, transparent);
-  transform: translateY(-1px);
 }
 
 .dialogTip {
@@ -528,22 +432,6 @@
   display: flex;
   justify-content: flex-end;
   gap: 12px;
-}
-
-.editButtonPrimary {
-  background-color: var(--primary);
-  color: var(--primary-foreground);
-  transition: background-color 0.2s ease, transform 0.2s ease;
-}
-
-.editButtonPrimary:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.editButtonPrimary:not(:disabled):hover {
-  background-color: color-mix(in oklab, var(--primary) 90%, transparent);
-  transform: translateY(-1px);
 }
 
 @keyframes notesScreenSpinner {

--- a/components/NotesScreen.tsx
+++ b/components/NotesScreen.tsx
@@ -13,7 +13,6 @@ import {
   Trash2,
   BookOpen,
   Sparkles,
-  NotebookPen,
 } from "lucide-react";
 
 import { useTranslationContext } from "./TranslationContext";
@@ -59,6 +58,7 @@ import { AudioNotePanel, type AudioNotePayload } from "./notes/AudioNotePanel";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKeys, STALE_TIMES } from "@/lib/query/keys";
 import { usePassageTextsMap } from "@/lib/query/passages";
+import controls from "@/components/realign/controls.module.css";
 import styles from "./NotesScreen.module.css";
 
 interface NotesScreenProps {
@@ -304,90 +304,6 @@ export function NotesScreen({ onNavigate }: NotesScreenProps = {}) {
     });
   }, [derivedNotes, searchQuery]);
 
-  const noteCount = notes.length;
-  const verseLinkedCount = useMemo(
-    () => derivedNotes.filter((note) => Boolean(note.referenceLabel)).length,
-    [derivedNotes]
-  );
-  const verseLinkedPercent =
-    noteCount > 0 ? Math.round((verseLinkedCount / noteCount) * 100) : 0;
-
-  const averageWordCount = useMemo(() => {
-    if (noteCount === 0) {
-      return 0;
-    }
-    const totalWords = derivedNotes.reduce((sum, note) => {
-      const count = note.body.split(/\s+/).filter(Boolean).length;
-      return sum + count;
-    }, 0);
-    return Math.max(1, Math.round(totalWords / noteCount));
-  }, [derivedNotes, noteCount]);
-
-  const latestNoteLabel = useMemo(() => {
-    if (notes.length === 0) {
-      return "First note awaits";
-    }
-    const mostRecent = notes.reduce<UserNote | null>((current, candidate) => {
-      if (!current) {
-        return candidate;
-      }
-      const candidateDate = new Date(
-        candidate.updatedAt ?? candidate.createdAt ?? 0
-      );
-      const currentDate = new Date(current.updatedAt ?? current.createdAt ?? 0);
-      return candidateDate > currentDate ? candidate : current;
-    }, null);
-
-    return (
-      formatDate(mostRecent?.updatedAt ?? mostRecent?.createdAt ?? null) ??
-      "Recently updated"
-    );
-  }, [notes]);
-
-  const headerMeta = useMemo(() => {
-    const savedLabel = `${noteCount} ${
-      noteCount === 1 ? "saved reflection" : "saved reflections"
-    }`;
-    const linkedLabel = `${verseLinkedCount} ${
-      verseLinkedCount === 1
-        ? "note linked to scripture"
-        : "notes linked to scripture"
-    }`;
-    return `${savedLabel} • ${linkedLabel}`;
-  }, [noteCount, verseLinkedCount]);
-
-  const statsCards = useMemo(
-    () => [
-      {
-        label: "Total reflections",
-        value: String(noteCount),
-        context:
-          noteCount === 0
-            ? "Start journaling your study insights."
-            : `${noteCount === 1 ? "Entry" : "Entries"} saved in your library.`,
-      },
-      {
-        label: "Scripture-linked",
-        value: noteCount === 0 ? "0" : `${verseLinkedPercent}%`,
-        context:
-          noteCount === 0
-            ? "Link passages to give your notes more context."
-            : `${verseLinkedCount} ${
-                verseLinkedCount === 1 ? "note" : "notes"
-              } include a verse.`,
-      },
-      {
-        label: "Average length",
-        value: noteCount === 0 ? "—" : `${averageWordCount} words`,
-        context:
-          noteCount === 0
-            ? "Your writing trends will appear here."
-            : "Typical note size across your reflections.",
-      },
-    ],
-    [noteCount, verseLinkedPercent, verseLinkedCount, averageWordCount]
-  );
-
   const handleCreateNote = async () => {
     if (!translationCode) {
       setCreateError("Select a translation before creating notes.");
@@ -554,7 +470,6 @@ export function NotesScreen({ onNavigate }: NotesScreenProps = {}) {
         <div className={styles.headerBar}>
           <div className={styles.headerTitleWrap}>
             <h1 className={styles.headerTitle}>Reflections</h1>
-            <p className={styles.headerMeta}>{headerMeta}</p>
           </div>
           <div className={styles.headerActions}>
             <TranslationSwitcher
@@ -563,16 +478,15 @@ export function NotesScreen({ onNavigate }: NotesScreenProps = {}) {
               hideLabel
             />
             <Button
-              size="lg"
               variant="outline"
+              className={controls.btnSecondary}
               disabled={books.length === 0 || !translationCode}
               onClick={() => setIsAudioNoteOpen(true)}
             >
-              🎙 Record Note
+              Record Note
             </Button>
             <Button
-              size="lg"
-              className={styles.addButton}
+              className={controls.btnPrimary}
               disabled={books.length === 0 || !translationCode}
               onClick={() => setIsCreateOpen(true)}
             >
@@ -582,33 +496,13 @@ export function NotesScreen({ onNavigate }: NotesScreenProps = {}) {
           </div>
         </div>
 
-        <div className={styles.statsRow}>
-          {statsCards.map((card, index) => (
-            <motion.div
-              key={card.label}
-              className={styles.statCard}
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{
-                duration: 0.3,
-                ease: "easeOut",
-                delay: index * 0.04,
-              }}
-            >
-              <p className={styles.statLabel}>{card.label}</p>
-              <span className={styles.statValue}>{card.value}</span>
-              <p className={styles.statContext}>{card.context}</p>
-            </motion.div>
-          ))}
-        </div>
-
         <div className={styles.searchWrap}>
           <Search className={styles.searchIcon} aria-hidden="true" />
           <Input
             placeholder="Search your reflections..."
             value={searchQuery}
             onChange={(event) => setSearchQuery(event.target.value)}
-            className={styles.searchInput}
+            className={`${controls.control} ${styles.searchInput}`}
           />
         </div>
       </div>
@@ -660,48 +554,6 @@ export function NotesScreen({ onNavigate }: NotesScreenProps = {}) {
               </div>
             </motion.div>
 
-            <motion.div
-              className={styles.dialogMetaRow}
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.28, ease: "easeOut", delay: 0.05 }}
-            >
-              <div className={styles.dialogMetaTile}>
-                <NotebookPen
-                  className={styles.dialogMetaIcon}
-                  aria-hidden="true"
-                />
-                <div>
-                  <p className={styles.dialogMetaLabel}>Saved reflections</p>
-                  <p className={styles.dialogMetaValue}>{noteCount}</p>
-                </div>
-              </div>
-              <div className={styles.dialogMetaTile}>
-                <BookOpen
-                  className={styles.dialogMetaIcon}
-                  aria-hidden="true"
-                />
-                <div>
-                  <p className={styles.dialogMetaLabel}>Linked verses</p>
-                  <p className={styles.dialogMetaValue}>
-                    {noteCount === 0 ? "—" : `${verseLinkedPercent}%`}
-                  </p>
-                </div>
-              </div>
-              <div className={styles.dialogMetaTile}>
-                <Calendar
-                  className={styles.dialogMetaIcon}
-                  aria-hidden="true"
-                />
-                <div>
-                  <p className={styles.dialogMetaLabel}>Last updated</p>
-                  <p className={styles.dialogMetaValue}>{latestNoteLabel}</p>
-                </div>
-              </div>
-            </motion.div>
-
-            <div className={styles.dialogDivider} />
-
             <div className={styles.formStack}>
               <motion.div
                 className={`${styles.fieldGrid} ${styles.fieldGridTwoColumns}`}
@@ -720,7 +572,7 @@ export function NotesScreen({ onNavigate }: NotesScreenProps = {}) {
                       setCreateVerseEnd("1");
                     }}
                   >
-                    <SelectTrigger className={styles.selectTrigger}>
+                    <SelectTrigger className={`${controls.control} ${styles.selectTrigger}`}>
                       <SelectValue placeholder="Select book" />
                     </SelectTrigger>
                     <SelectContent className={`${styles.selectContent} z-[9999]`}>
@@ -753,7 +605,7 @@ export function NotesScreen({ onNavigate }: NotesScreenProps = {}) {
                       setCreateVerseEnd("1");
                     }}
                   >
-                    <SelectTrigger className={styles.selectTrigger}>
+                    <SelectTrigger className={`${controls.control} ${styles.selectTrigger}`}>
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent className={`${styles.selectContent} z-[9999]`}>
@@ -790,7 +642,7 @@ export function NotesScreen({ onNavigate }: NotesScreenProps = {}) {
                     min={1}
                     value={createVerseStart}
                     onChange={(event) => setCreateVerseStart(event.target.value)}
-                    className={styles.input}
+                    className={`${controls.control} ${styles.input}`}
                   />
                   <p className={styles.dialogHint}>
                     We&apos;ll fetch the verse text automatically.
@@ -803,7 +655,7 @@ export function NotesScreen({ onNavigate }: NotesScreenProps = {}) {
                     min={createVerseStart}
                     value={createVerseEnd}
                     onChange={(event) => setCreateVerseEnd(event.target.value)}
-                    className={styles.input}
+                    className={`${controls.control} ${styles.input}`}
                   />
                   <p className={styles.dialogHint}>
                     Use the same number to capture a single verse.
@@ -821,7 +673,7 @@ export function NotesScreen({ onNavigate }: NotesScreenProps = {}) {
                   value={createBody}
                   onChange={(event) => setCreateBody(event.target.value)}
                   placeholder="Write your insights, prayers, and observations..."
-                  className={styles.textarea}
+                  className={`${controls.control} ${controls.controlTextarea} ${styles.textarea}`}
                 />
                 <p className={styles.dialogHint}>
                   Focus on what stood out, why it matters, and how you&apos;ll respond.
@@ -844,7 +696,7 @@ export function NotesScreen({ onNavigate }: NotesScreenProps = {}) {
                 transition={{ duration: 0.32, ease: "easeOut", delay: 0.2 }}
               >
                 <Button
-                  className={styles.saveButton}
+                  className={`${controls.btnPrimary} ${styles.saveButton}`}
                   onClick={handleCreateNote}
                   disabled={isSavingCreate}
                 >
@@ -972,18 +824,22 @@ export function NotesScreen({ onNavigate }: NotesScreenProps = {}) {
             <Textarea
               value={editBody}
               onChange={(event) => setEditBody(event.target.value)}
-              className={`${styles.textarea} ${styles.editTextarea}`}
+              className={`${controls.control} ${controls.controlTextarea} ${styles.textarea} ${styles.editTextarea}`}
             />
             {editError ? (
               <p className={styles.errorMessage}>{editError}</p>
             ) : null}
           </ModalBody>
           <ModalFooter className={styles.editActions} direction="row">
-            <Button variant="ghost" onClick={() => setEditingNote(null)}>
+            <Button
+              variant="outline"
+              className={controls.btnSecondary}
+              onClick={() => setEditingNote(null)}
+            >
               Cancel
             </Button>
             <Button
-              className={styles.editButtonPrimary}
+              className={controls.btnPrimary}
               onClick={handleUpdateNote}
               disabled={isSavingEdit}
             >

--- a/components/bible/BookCombobox.tsx
+++ b/components/bible/BookCombobox.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  Combobox,
+  type ComboboxProps,
+} from "@/components/ui/combobox";
+import { getBookSearchKeywords } from "@/lib/bible/filterBooks";
+import type { BibleBookSummary } from "@/types/bible";
+
+export type BookComboboxProps = {
+  books: BibleBookSummary[];
+  /** Selected book id or name, depending on `valueKey`. */
+  value?: string;
+  onValueChange: (value: string, book: BibleBookSummary) => void;
+  /**
+   * Which field to use as the combobox value.
+   * Pre-read forms store book **name**; reader/memory/notes store book **id**.
+   */
+  valueKey?: "id" | "name";
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+  disabled?: boolean;
+  className?: string;
+  triggerClassName?: string;
+  id?: string;
+  "aria-label"?: string;
+};
+
+/**
+ * Client-side Bible book typeahead. Reuses the generic Combobox and matches
+ * on name, abbreviation, and shared aliases (e.g. "gen", "1 cor").
+ */
+export function BookCombobox({
+  books,
+  value,
+  onValueChange,
+  valueKey = "id",
+  placeholder = "Choose a book",
+  searchPlaceholder = "Search books…",
+  emptyMessage = "No books match.",
+  disabled = false,
+  className,
+  triggerClassName,
+  id,
+  "aria-label": ariaLabel = "Bible book",
+}: BookComboboxProps) {
+  const options = React.useMemo(
+    () =>
+      books.map((book) => ({
+        value: valueKey === "name" ? book.name : book.id,
+        label: book.name,
+        keywords: getBookSearchKeywords(book),
+      })),
+    [books, valueKey],
+  );
+
+  const bookByValue = React.useMemo(() => {
+    const map = new Map<string, BibleBookSummary>();
+    for (const book of books) {
+      map.set(valueKey === "name" ? book.name : book.id, book);
+    }
+    return map;
+  }, [books, valueKey]);
+
+  const handleChange: ComboboxProps["onValueChange"] = (next) => {
+    const book = bookByValue.get(next);
+    if (!book) return;
+    onValueChange(next, book);
+  };
+
+  return (
+    <Combobox
+      id={id}
+      options={options}
+      value={value}
+      onValueChange={handleChange}
+      placeholder={placeholder}
+      searchPlaceholder={searchPlaceholder}
+      emptyMessage={emptyMessage}
+      disabled={disabled}
+      className={className}
+      triggerClassName={triggerClassName}
+      aria-label={ariaLabel}
+    />
+  );
+}

--- a/components/bible/VerseRangePicker.module.css
+++ b/components/bible/VerseRangePicker.module.css
@@ -1,0 +1,40 @@
+.root {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 0.55rem 0.65rem;
+  align-items: end;
+  width: 100%;
+  min-width: 0;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.subLabel {
+  font-size: 0.78rem;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  color: #6b5a52;
+}
+
+.separator {
+  align-self: center;
+  padding-bottom: 0.15rem;
+  color: #6b5a52;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+@media (max-width: 419px) {
+  .root {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .separator {
+    display: none;
+  }
+}

--- a/components/bible/VerseRangePicker.tsx
+++ b/components/bible/VerseRangePicker.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { Combobox } from "@/components/ui/combobox";
+import {
+  formatVerseRange,
+  parseVerseRangeValue,
+} from "@/lib/bible/verseRange";
+
+import styles from "./VerseRangePicker.module.css";
+
+export type VerseRangePickerProps = {
+  /** Total verses in the selected chapter; null until book+chapter are known. */
+  verseCount: number | null;
+  /** Stored range string, e.g. `"1-26"` or `"5"`. */
+  value: string;
+  onValueChange: (range: string) => void;
+  disabled?: boolean;
+  className?: string;
+  triggerClassName?: string;
+};
+
+export { formatVerseRange, parseVerseRangeValue } from "@/lib/bible/verseRange";
+
+/**
+ * Client-side from/to verse dropdowns. Bounds come from the loaded chapter.
+ */
+export function VerseRangePicker({
+  verseCount,
+  value,
+  onValueChange,
+  disabled = false,
+  className,
+  triggerClassName,
+}: VerseRangePickerProps) {
+  const ready = typeof verseCount === "number" && verseCount > 0;
+  const parsed = parseVerseRangeValue(value);
+  const start = parsed?.start;
+  const end = parsed?.end;
+
+  const startOptions = useMemo(() => {
+    if (!ready || !verseCount) return [];
+    return Array.from({ length: verseCount }, (_value, index) => {
+      const verse = index + 1;
+      return {
+        value: String(verse),
+        label: String(verse),
+        keywords: [String(verse)],
+      };
+    });
+  }, [ready, verseCount]);
+
+  const endOptions = useMemo(() => {
+    if (!ready || !verseCount) return [];
+    const min = start && start >= 1 ? start : 1;
+    return Array.from({ length: verseCount - min + 1 }, (_value, index) => {
+      const verse = min + index;
+      return {
+        value: String(verse),
+        label: String(verse),
+        keywords: [String(verse)],
+      };
+    });
+  }, [ready, verseCount, start]);
+
+  const isDisabled = disabled || !ready;
+
+  const handleStartChange = (nextStartRaw: string) => {
+    if (!verseCount) return;
+    const nextStart = Number.parseInt(nextStartRaw, 10);
+    if (!Number.isFinite(nextStart)) return;
+    const nextEnd =
+      end && end >= nextStart ? end : Math.max(nextStart, end ?? nextStart);
+    const clampedEnd = Math.min(Math.max(nextEnd, nextStart), verseCount);
+    onValueChange(formatVerseRange(nextStart, clampedEnd));
+  };
+
+  const handleEndChange = (nextEndRaw: string) => {
+    if (!verseCount) return;
+    const nextEnd = Number.parseInt(nextEndRaw, 10);
+    if (!Number.isFinite(nextEnd)) return;
+    const nextStart = start && start >= 1 ? Math.min(start, nextEnd) : 1;
+    onValueChange(formatVerseRange(nextStart, nextEnd));
+  };
+
+  return (
+    <div className={[styles.root, className].filter(Boolean).join(" ")}>
+      <div className={styles.field}>
+        <span className={styles.subLabel}>From</span>
+        <Combobox
+          options={startOptions}
+          value={start ? String(start) : undefined}
+          onValueChange={handleStartChange}
+          disabled={isDisabled}
+          placeholder={ready ? "Start" : "Select chapter first"}
+          searchPlaceholder="Verse…"
+          emptyMessage="No verses."
+          triggerClassName={triggerClassName}
+          aria-label="Start verse"
+        />
+      </div>
+      <span className={styles.separator} aria-hidden="true">
+        to
+      </span>
+      <div className={styles.field}>
+        <span className={styles.subLabel}>To</span>
+        <Combobox
+          options={endOptions}
+          value={end ? String(end) : undefined}
+          onValueChange={handleEndChange}
+          disabled={isDisabled || !start}
+          placeholder={ready ? "End" : "Select chapter first"}
+          searchPlaceholder="Verse…"
+          emptyMessage="No verses."
+          triggerClassName={triggerClassName}
+          aria-label="End verse"
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/notes/AudioNotePanel.tsx
+++ b/components/notes/AudioNotePanel.tsx
@@ -30,6 +30,7 @@ import {
   type AudioNoteStage,
 } from "./audioNoteStages";
 
+import controls from "@/components/realign/controls.module.css";
 import styles from "./AudioNotePanel.module.css";
 
 type SubmitPayload = {
@@ -395,7 +396,7 @@ export function AudioNotePanel({
           This browser does not support the Web Speech API. Try using Chrome, Edge,
           or another browser with speech recognition support.
         </p>
-        <Button onClick={onClose}>Close</Button>
+        <Button className={controls.btnSecondary} onClick={onClose}>Close</Button>
       </div>
     );
   }
@@ -416,10 +417,14 @@ export function AudioNotePanel({
 
       {stage === "idle" ? (
         <div className={styles.controlRow}>
-          <Button onClick={beginReferenceRecording}>
+          <Button className={controls.btnPrimary} onClick={beginReferenceRecording}>
             <Mic size={16} /> Start recording reference
           </Button>
-          <Button variant="ghost" onClick={onClose}>
+          <Button
+            variant="outline"
+            className={controls.btnSecondary}
+            onClick={onClose}
+          >
             Cancel
           </Button>
         </div>
@@ -427,7 +432,7 @@ export function AudioNotePanel({
 
       {stage === "recording-reference" ? (
         <div className={styles.controlRow}>
-          <Button variant="destructive" onClick={handleStop}>
+          <Button className={controls.btnDanger} onClick={handleStop}>
             <Square size={16} /> Stop
           </Button>
           <div className={styles.infoBanner}>🎧 Listening for reference…</div>
@@ -449,7 +454,7 @@ export function AudioNotePanel({
                 value={selectedBookId ?? undefined}
                 onValueChange={(value) => setSelectedBookId(value)}
               >
-                <SelectTrigger id="audio-note-book">
+                <SelectTrigger id="audio-note-book" className={controls.control}>
                   <SelectValue placeholder="Select book" />
                 </SelectTrigger>
                 <SelectContent>
@@ -470,6 +475,7 @@ export function AudioNotePanel({
                 value={chapterValue}
                 onChange={(event) => setChapterValue(event.target.value)}
                 inputMode="numeric"
+                className={controls.control}
               />
             </div>
             <div className={styles.field}>
@@ -481,6 +487,7 @@ export function AudioNotePanel({
                 value={verseStartValue}
                 onChange={(event) => setVerseStartValue(event.target.value)}
                 inputMode="numeric"
+                className={controls.control}
               />
             </div>
             <div className={styles.field}>
@@ -492,21 +499,31 @@ export function AudioNotePanel({
                 value={verseEndValue}
                 onChange={(event) => setVerseEndValue(event.target.value)}
                 inputMode="numeric"
+                className={controls.control}
               />
             </div>
           </div>
           <div className={styles.actions}>
-            <Button variant="ghost" onClick={handleRestart}>
+            <Button
+              variant="outline"
+              className={controls.btnSecondary}
+              onClick={handleRestart}
+            >
               <RotateCcw size={16} /> Restart
             </Button>
-            <Button onClick={handleReferenceConfirm}>Next: record note</Button>
+            <Button
+              className={controls.btnPrimary}
+              onClick={handleReferenceConfirm}
+            >
+              Next: record note
+            </Button>
           </div>
         </>
       ) : null}
 
       {stage === "recording-note" ? (
         <div className={styles.controlRow}>
-          <Button variant="destructive" onClick={handleStop}>
+          <Button className={controls.btnDanger} onClick={handleStop}>
             <Square size={16} /> Stop
           </Button>
           <div className={styles.infoBanner}>🎙 Recording note…</div>
@@ -521,27 +538,27 @@ export function AudioNotePanel({
           <Textarea
             value={noteBody}
             onChange={(event) => setNoteBody(event.target.value)}
-            className={styles.noteTextarea}
+            className={`${controls.control} ${controls.controlTextarea} ${styles.noteTextarea}`}
             placeholder="Edit your note before saving..."
           />
           <div className={styles.actions}>
-            <Button variant="ghost" onClick={handleRestart}>
+            <Button
+              variant="outline"
+              className={controls.btnSecondary}
+              onClick={handleRestart}
+            >
               <RotateCcw size={16} /> Restart
             </Button>
-            <Button onClick={handleSave} disabled={isSaving}>
+            <Button
+              className={controls.btnPrimary}
+              onClick={handleSave}
+              disabled={isSaving}
+            >
               {isSaving ? <Loader2 size={16} className="animate-spin" /> : null}
               Save note
             </Button>
           </div>
         </>
-      ) : null}
-
-      {stage === "idle" ? (
-        <div className={styles.actions}>
-          <Button variant="ghost" onClick={onClose}>
-            Cancel
-          </Button>
-        </div>
       ) : null}
     </div>
   );

--- a/components/pre-read/CommentsSection.module.css
+++ b/components/pre-read/CommentsSection.module.css
@@ -1,40 +1,41 @@
 .card {
-  border-radius: 1.5rem;
-  border: 1px solid var(--border);
-  background: color-mix(in oklab, var(--card) 92%, transparent);
-  box-shadow: 0 18px 48px color-mix(in oklab, var(--foreground) 6%, transparent);
+  border-radius: 1rem;
+  border: 1px solid #e8cfc4;
+  background: #ffffff;
+  box-shadow: 0 8px 24px color-mix(in oklab, #d91f26 6%, transparent);
   padding: 1.25rem;
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
-  backdrop-filter: blur(12px);
+  gap: 1.15rem;
 }
 
 .header {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
+  gap: 0.25rem;
   text-align: left;
 }
 
 .eyebrow {
-  font-size: 0.75rem;
+  margin: 0;
+  font-size: 0.65rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.35em;
-  color: var(--muted-foreground);
+  letter-spacing: 0.12em;
+  color: #d91f26;
 }
 
 .title {
-  font-size: 1.4rem;
-  font-weight: 600;
-  color: var(--foreground);
   margin: 0;
+  font-size: 1.2rem;
+  font-weight: 750;
+  color: #1a1a1a;
 }
 
 .subtitle {
-  font-size: 0.9rem;
-  color: var(--muted-foreground);
   margin: 0;
+  font-size: 0.9rem;
+  color: #4a4a4a;
 }
 
 .editor {
@@ -43,14 +44,11 @@
   gap: 0.75rem;
 }
 
-.editor :global(textarea) {
-  font-size: 0.95rem;
-  border-radius: 1rem;
-}
-
 .editorActions {
   display: flex;
   justify-content: flex-end;
+  gap: 0.65rem;
+  flex-wrap: wrap;
 }
 
 .list {
@@ -63,115 +61,102 @@
 }
 
 .item {
-  border-radius: 1.25rem;
-  border: 1px solid var(--border);
-  background: color-mix(in oklab, var(--background) 96%, transparent);
+  border-radius: 0.9rem;
+  border: 1px solid #e8cfc4;
+  background: #fff8f4;
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  min-width: 0;
 }
 
 .itemHeader {
   display: flex;
   align-items: center;
   gap: 0.6rem;
+  min-width: 0;
 }
 
 .itemAvatar {
   width: 2.25rem;
   height: 2.25rem;
+  flex-shrink: 0;
 }
 
 .itemMeta {
   display: flex;
   flex-direction: column;
+  min-width: 0;
 }
 
 .itemName {
-  font-size: 0.95rem;
-  font-weight: 600;
   margin: 0;
+  font-size: 0.95rem;
+  font-weight: 650;
+  color: #1a1a1a;
 }
 
 .itemTimestamp {
   font-size: 0.75rem;
-  color: var(--muted-foreground);
+  color: #6b5a52;
 }
 
 .itemBody {
+  margin: 0;
   font-size: 0.95rem;
   line-height: 1.5;
-  margin: 0;
+  color: #1a1a1a;
+  overflow-wrap: anywhere;
 }
 
 .itemActions {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
-  font-size: 0.8rem;
-}
-
-.actionButton {
-  border: none;
-  background: color-mix(in oklab, var(--primary) 12%, transparent);
-  color: var(--primary);
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: background 150ms ease, color 150ms ease;
-}
-
-.actionButton:hover {
-  background: color-mix(in oklab, var(--primary) 25%, transparent);
-  color: var(--primary-foreground, #fff);
-}
-
-.deleteButton {
-  background: color-mix(in oklab, var(--destructive) 12%, transparent);
-  color: color-mix(in oklab, var(--destructive) 70%, var(--foreground));
-}
-
-.deleteButton:hover {
-  background: color-mix(in oklab, var(--destructive) 25%, transparent);
-  color: #fff;
 }
 
 .replyTrail {
-  margin: 0 0 0 3rem;
-  border-left: 1px solid var(--border);
-  padding-left: 1rem;
+  margin: 0 0 0 2.5rem;
+  border-left: 1.5px solid #e8cfc4;
+  padding-left: 0.9rem;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
   list-style: none;
+  min-width: 0;
 }
 
 .replyActions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.55rem;
   flex-wrap: wrap;
-}
-
-@media (min-width: 640px) {
-  .card {
-    padding: 1.75rem;
-  }
-
-  .item {
-    padding: 1.25rem;
-  }
-
-  .replyTrail {
-    margin-left: 3.5rem;
-  }
 }
 
 .empty {
   text-align: center;
-  color: var(--muted-foreground);
+  color: #6b5a52;
   font-size: 0.9rem;
+}
+
+@media (min-width: 640px) {
+  .card {
+    padding: 1.5rem;
+  }
+
+  .replyTrail {
+    margin-left: 3rem;
+  }
+}
+
+@media (max-width: 719px) {
+  .editorActions,
+  .replyActions {
+    flex-direction: column;
+  }
+
+  .editorActions :global(button),
+  .replyActions :global(button) {
+    width: 100%;
+  }
 }

--- a/components/pre-read/CommentsSection.tsx
+++ b/components/pre-read/CommentsSection.tsx
@@ -3,9 +3,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Avatar, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import controls from "@/components/realign/controls.module.css";
 
 import styles from "./CommentsSection.module.css";
 
@@ -61,14 +62,6 @@ const CommentItem = ({
   onDelete,
   setReplyValue,
 }: CommentItemProps) => {
-  const fallback =
-    comment.author.username
-      ?.split(" ")
-      .map((part) => part[0])
-      .join("")
-      .slice(0, 2)
-      .toUpperCase() ?? "M";
-
   return (
     <li className={styles.item}>
       <div className={styles.itemHeader}>
@@ -79,8 +72,6 @@ const CommentItem = ({
               alt={comment.author.username ?? "Member"}
             />
           ) : null}
-
-          {/* <AvatarFallback>{fallback}</AvatarFallback> */}
         </Avatar>
         <div className={styles.itemMeta}>
           <p className={styles.itemName}>
@@ -95,7 +86,7 @@ const CommentItem = ({
       <div className={styles.itemActions}>
         <button
           type="button"
-          className={styles.actionButton}
+          className={controls.btnGhost}
           onClick={() =>
             onReplyToggle(replyingTo === comment.id ? null : comment.id)
           }
@@ -105,7 +96,7 @@ const CommentItem = ({
         {comment.can_delete ? (
           <button
             type="button"
-            className={`${styles.actionButton} ${styles.deleteButton}`}
+            className={controls.btnDanger}
             onClick={() => onDelete(comment.id)}
           >
             Delete
@@ -119,19 +110,20 @@ const CommentItem = ({
             value={replyValue}
             onChange={(event) => setReplyValue(event.target.value)}
             rows={2}
+            className={`${controls.control} ${controls.controlTextarea}`}
           />
           <div className={styles.replyActions}>
             <Button
               type="button"
-              size="sm"
+              className={controls.btnPrimary}
               onClick={() => onReplySubmit(comment.id)}
             >
               Post Reply
             </Button>
             <Button
               type="button"
-              variant="ghost"
-              size="sm"
+              variant="outline"
+              className={controls.btnSecondary}
               onClick={() => onReplyToggle(null)}
             >
               Cancel
@@ -320,10 +312,12 @@ export function CommentsSection({
           value={newComment}
           onChange={(event) => setNewComment(event.target.value)}
           rows={3}
+          className={`${controls.control} ${controls.controlTextarea}`}
         />
         <div className={styles.editorActions}>
           <Button
             type="button"
+            className={controls.btnPrimary}
             onClick={() => postComment(newComment, null)}
             disabled={submitting}
           >

--- a/components/pre-read/PollWidget.module.css
+++ b/components/pre-read/PollWidget.module.css
@@ -1,9 +1,9 @@
 .card {
-  border-radius: 1.5rem;
-  border: 1px solid var(--border);
-  background: var(--surface-glass-gradient);
-  box-shadow: 0 18px 48px color-mix(in oklab, var(--foreground) 8%, transparent);
-  padding: 1.5rem;
+  border-radius: 1rem;
+  border: 1px solid #e8cfc4;
+  background: #ffffff;
+  box-shadow: 0 8px 24px color-mix(in oklab, #d91f26 6%, transparent);
+  padding: 1.25rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -12,55 +12,74 @@
 .header {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
+  gap: 0.25rem;
 }
 
 .eyebrow {
-  font-size: 0.75rem;
-  letter-spacing: 0.35em;
+  margin: 0;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--muted-foreground);
+  color: #d91f26;
 }
 
 .question {
-  font-size: 1.2rem;
-  font-weight: 600;
-  color: var(--foreground);
   margin: 0;
+  font-size: 1.15rem;
+  font-weight: 750;
+  color: #1a1a1a;
+  overflow-wrap: anywhere;
 }
 
 .meta {
+  margin: 0;
   font-size: 0.85rem;
-  color: var(--muted-foreground);
+  color: #6b5a52;
 }
 
 .options {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.85rem;
 }
 
 .option {
-  border-radius: 1.25rem;
-  border: 1px solid var(--border);
-  background: color-mix(in oklab, var(--card) 85%, transparent);
+  border-radius: 0.9rem;
+  border: 1px solid #e8cfc4;
+  background: #fff8f4;
   padding: 1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.65rem;
+  min-width: 0;
 }
 
 .optionHeader {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  color: var(--foreground);
+  gap: 0.75rem;
+  color: #1a1a1a;
+  min-width: 0;
+}
+
+.optionHeader p {
+  margin: 0;
+  font-weight: 650;
+  overflow-wrap: anywhere;
+}
+
+.optionHeader span {
+  flex-shrink: 0;
+  font-size: 0.8rem;
+  color: #6b5a52;
 }
 
 .progress {
   height: 0.45rem;
   border-radius: 999px;
-  background: color-mix(in oklab, var(--secondary) 35%, transparent);
+  background: #ffe8dc;
   position: relative;
   overflow: hidden;
 }
@@ -69,4 +88,15 @@
   height: 100%;
   border-radius: inherit;
   transition: width 200ms ease;
+  background: #d91f26;
+}
+
+.progressFillMuted {
+  background: color-mix(in oklab, #d91f26 28%, #e0c4b6);
+}
+
+@media (max-width: 719px) {
+  .option :global(button) {
+    width: 100%;
+  }
 }

--- a/components/pre-read/PollWidget.tsx
+++ b/components/pre-read/PollWidget.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import type { PollSnapshot } from "@/lib/pre-read/poll";
+import controls from "@/components/realign/controls.module.css";
 
 import styles from "./PollWidget.module.css";
 
@@ -161,19 +162,19 @@ export function PollWidget({
               </div>
               <div className={styles.progress}>
                 <div
-                  className={styles.progressFill}
+                  className={`${styles.progressFill} ${
+                    isSelected ? "" : styles.progressFillMuted
+                  }`}
                   style={{
                     width: `${percentages[index]}%`,
-                    background: isSelected
-                      ? "var(--primary)"
-                      : "color-mix(in oklab, var(--primary) 20%, transparent)",
                   }}
                 />
               </div>
               <Button
                 type="button"
-                variant={isSelected ? "default" : "secondary"}
-                size="sm"
+                className={
+                  isSelected ? controls.btnPrimary : controls.btnSecondary
+                }
                 disabled={isSubmitting}
                 onClick={() => handleVote(index)}
               >

--- a/components/pre-read/StreamHostCard.module.css
+++ b/components/pre-read/StreamHostCard.module.css
@@ -72,22 +72,33 @@
 .link {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  border-radius: 999px;
-  background: color-mix(in oklab, var(--primary) 25%, transparent);
-  color: var(--primary-foreground);
-  padding: 0.45rem 1rem;
-  text-transform: uppercase;
-  font-size: 0.72rem;
-  letter-spacing: 0.25em;
-  transition: background 180ms ease;
+  justify-content: center;
+  gap: 0.45rem;
+  min-height: 3.5rem;
+  padding: 0.75rem 1.35rem;
+  border-radius: 0.8rem;
+  border: 0;
+  background: linear-gradient(160deg, #d91f26, #f28c00);
+  color: #ffffff;
+  font-size: 0.95rem;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 10px 24px color-mix(in oklab, #d91f26 28%, transparent);
+  transition: filter 150ms ease;
 }
 
 .linkIcon {
-  width: 0.85rem;
-  height: 0.85rem;
+  width: 0.95rem;
+  height: 0.95rem;
 }
 
 .link:hover {
-  background: color-mix(in oklab, var(--primary) 35%, transparent);
+  filter: brightness(1.05);
+  color: #ffffff;
+}
+
+@media (min-width: 768px) {
+  .link {
+    min-height: 2.75rem;
+  }
 }

--- a/components/realign/controls.module.css
+++ b/components/realign/controls.module.css
@@ -1,0 +1,174 @@
+/* Shared Realign form controls — mirrors admin PreReadForm .control / buttons */
+
+.control {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0 !important;
+  min-height: 3.5rem;
+  height: auto;
+  border-radius: 0.8rem;
+  border: 1.5px solid #e0c4b6;
+  background: #fff8f4;
+  padding: 0.85rem 1rem;
+  font-size: 1.05rem;
+  line-height: 1.4;
+  color: #1a1a1a;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease,
+    background 150ms ease;
+}
+
+.control::placeholder {
+  color: #8a7268;
+}
+
+.control:hover:not(:disabled) {
+  border-color: color-mix(in oklab, #d91f26 35%, #e0c4b6);
+  background: #ffffff;
+}
+
+.control:focus-visible {
+  outline: none;
+  border-color: #d91f26;
+  background: #ffffff;
+  box-shadow: 0 0 0 3px color-mix(in oklab, #d91f26 18%, transparent);
+}
+
+.control:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+textarea.control,
+.controlTextarea {
+  min-height: 8.5rem;
+  resize: vertical;
+  overflow-wrap: anywhere;
+}
+
+.btnPrimary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  min-height: 3.5rem;
+  min-width: 8.5rem;
+  padding: 0.75rem 1.5rem;
+  border: 0;
+  border-radius: 0.8rem;
+  background: linear-gradient(160deg, #d91f26, #f28c00);
+  color: #ffffff;
+  font-size: 1rem;
+  font-weight: 700;
+  box-shadow: 0 10px 24px color-mix(in oklab, #d91f26 28%, transparent);
+  cursor: pointer;
+  transition: filter 150ms ease, color 150ms ease;
+}
+
+.btnPrimary:hover:not(:disabled) {
+  filter: brightness(1.05);
+  color: #ffffff;
+}
+
+.btnPrimary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btnSecondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  min-height: 3.5rem;
+  min-width: 8.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.8rem;
+  border: 1.5px solid #e0c4b6;
+  background: #ffffff;
+  color: #1a1a1a;
+  font-size: 1rem;
+  font-weight: 650;
+  cursor: pointer;
+  transition:
+    border-color 150ms ease,
+    background 150ms ease,
+    color 150ms ease;
+}
+
+.btnSecondary:hover:not(:disabled) {
+  border-color: #d91f26;
+  background: color-mix(in oklab, #d91f26 10%, #ffffff);
+  color: #d91f26;
+}
+
+.btnSecondary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btnGhost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 2.75rem;
+  padding: 0.5rem 0.95rem;
+  border-radius: 0.75rem;
+  border: 1.5px solid transparent;
+  background: color-mix(in oklab, #d91f26 10%, transparent);
+  color: #d91f26;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease, border-color 150ms ease;
+}
+
+.btnGhost:hover:not(:disabled) {
+  background: color-mix(in oklab, #d91f26 18%, transparent);
+  border-color: color-mix(in oklab, #d91f26 25%, transparent);
+}
+
+.btnDanger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 2.75rem;
+  padding: 0.5rem 0.95rem;
+  border-radius: 0.75rem;
+  border: 1.5px solid transparent;
+  background: color-mix(in oklab, #b91c1c 10%, transparent);
+  color: #b91c1c;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease, border-color 150ms ease;
+}
+
+.btnDanger:hover:not(:disabled) {
+  background: color-mix(in oklab, #b91c1c 22%, transparent);
+  border-color: color-mix(in oklab, #b91c1c 30%, transparent);
+  color: #ffffff;
+}
+
+@media (min-width: 768px) {
+  .control {
+    min-height: 3rem;
+    padding: 0.75rem 0.95rem;
+    font-size: 1rem;
+  }
+
+  .btnPrimary,
+  .btnSecondary {
+    min-height: 2.75rem;
+    font-size: 0.95rem;
+  }
+
+  textarea.control,
+  .controlTextarea {
+    min-height: 8rem;
+  }
+}

--- a/components/ui/Combobox.module.css
+++ b/components/ui/Combobox.module.css
@@ -1,0 +1,194 @@
+.root {
+  width: 100%;
+  min-width: 0;
+}
+
+.trigger {
+  box-sizing: border-box;
+  display: flex;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 3.5rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem;
+  border-radius: 0.8rem;
+  border: 1.5px solid #e0c4b6;
+  background: #fff8f4;
+  padding: 0.85rem 1rem;
+  color: #1a1a1a;
+  font-size: 1.05rem;
+  font-weight: 500;
+  line-height: 1.35;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease,
+    background 150ms ease;
+}
+
+.trigger:hover:not(:disabled) {
+  border-color: color-mix(in oklab, #d91f26 35%, #e0c4b6);
+  background: #ffffff;
+}
+
+.trigger:focus-visible {
+  outline: none;
+  border-color: #d91f26;
+  background: #ffffff;
+  box-shadow: 0 0 0 3px color-mix(in oklab, #d91f26 18%, transparent);
+}
+
+.trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.trigger[data-placeholder] {
+  color: #6b5a52;
+  font-weight: 450;
+}
+
+.triggerLabel {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chevron {
+  width: 1.1rem;
+  height: 1.1rem;
+  flex-shrink: 0;
+  color: #8a7268;
+  opacity: 0.9;
+}
+
+.content {
+  width: var(--radix-popover-trigger-width);
+  max-width: min(100vw - 1.5rem, 28rem);
+  padding: 0;
+  overflow: hidden;
+  border-radius: 0.9rem;
+  border: 1.5px solid #e8cfc4;
+  background: #ffffff;
+  box-shadow:
+    0 18px 40px color-mix(in oklab, #1a1a1a 12%, transparent),
+    0 2px 8px color-mix(in oklab, #d91f26 8%, transparent);
+}
+
+.searchRow {
+  padding: 0.7rem;
+  border-bottom: 1px solid #f0ddd4;
+  background: #fff8f4;
+}
+
+.searchInput {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 2.85rem;
+  border-radius: 0.7rem;
+  border: 1.5px solid #e0c4b6;
+  background: #ffffff;
+  padding: 0.65rem 0.85rem;
+  color: #1a1a1a;
+  font-size: 1rem;
+  line-height: 1.35;
+  outline: none;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.searchInput::placeholder {
+  color: #8a7268;
+}
+
+.searchInput:focus {
+  border-color: #d91f26;
+  box-shadow: 0 0 0 3px color-mix(in oklab, #d91f26 16%, transparent);
+}
+
+.list {
+  max-height: 16.5rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0.4rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+.empty {
+  margin: 0;
+  padding: 1rem 0.75rem;
+  text-align: center;
+  color: #6b5a52;
+  font-size: 0.95rem;
+}
+
+.option {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 0.55rem;
+  border: 0;
+  border-radius: 0.65rem;
+  background: transparent;
+  padding: 0.8rem 0.85rem;
+  color: #1a1a1a;
+  font-size: 1rem;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.option:hover,
+.option[data-active] {
+  background: color-mix(in oklab, #d91f26 10%, #fff5f0);
+  color: #1a1a1a;
+}
+
+.option[data-selected] {
+  background: color-mix(in oklab, #d91f26 14%, #ffe8dc);
+  color: #1a1a1a;
+}
+
+.option[data-selected][data-active] {
+  background: color-mix(in oklab, #d91f26 18%, #ffe0d0);
+}
+
+.optionLabel {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.check {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  color: #d91f26;
+}
+
+@media (min-width: 720px) {
+  .trigger {
+    min-height: 3rem;
+    padding: 0.75rem 0.95rem;
+    font-size: 1rem;
+  }
+
+  .searchInput {
+    min-height: 2.5rem;
+    font-size: 0.95rem;
+  }
+
+  .option {
+    padding: 0.65rem 0.75rem;
+    font-size: 0.95rem;
+  }
+}

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -4,14 +4,14 @@ import * as React from "react";
 import { CheckIcon, ChevronDownIcon } from "lucide-react";
 
 import { filterComboboxOptions } from "@/lib/bible/filterBooks";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/components/ui/utils";
+
+import styles from "./Combobox.module.css";
 
 export type ComboboxOption = {
   value: string;
@@ -132,39 +132,38 @@ export function Combobox({
   };
 
   return (
-    <div className={cn("w-full min-w-0", className)}>
+    <div className={cn(styles.root, className)}>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <Button
+          <button
             id={id}
             type="button"
-            variant="outline"
             role="combobox"
             aria-expanded={open}
+            aria-controls={id ? `${id}-listbox` : undefined}
             aria-label={ariaLabel}
             disabled={disabled}
-            className={cn(
-              "border-input data-[placeholder]:text-muted-foreground flex h-9 w-full min-w-0 items-center justify-between gap-2 rounded-md border bg-input-background px-3 py-2 text-sm font-normal whitespace-nowrap shadow-none transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
-              !selected && "text-muted-foreground",
-              triggerClassName,
-            )}
+            data-placeholder={!selected ? "" : undefined}
+            className={cn(styles.trigger, triggerClassName)}
           >
-            <span className="min-w-0 flex-1 truncate text-left">
+            <span className={styles.triggerLabel}>
               {selected?.label ?? placeholder}
             </span>
-            <ChevronDownIcon className="size-4 shrink-0 opacity-50" />
-          </Button>
+            <ChevronDownIcon className={styles.chevron} aria-hidden="true" />
+          </button>
         </PopoverTrigger>
         <PopoverContent
           align="start"
+          sideOffset={6}
           className={cn(
-            "w-[var(--radix-popover-trigger-width)] p-0",
+            "w-[var(--radix-popover-trigger-width)] max-w-[min(100vw-1.5rem,28rem)] border-0 bg-transparent p-0 shadow-none",
+            styles.content,
             contentClassName,
           )}
           onOpenAutoFocus={(event) => event.preventDefault()}
         >
-          <div className="border-b p-2">
-            <Input
+          <div className={styles.searchRow}>
+            <input
               ref={searchRef}
               value={query}
               onChange={(event) => {
@@ -173,7 +172,7 @@ export function Combobox({
               }}
               onKeyDown={onSearchKeyDown}
               placeholder={searchPlaceholder}
-              className="h-10"
+              className={styles.searchInput}
               aria-autocomplete="list"
               aria-controls={id ? `${id}-listbox` : undefined}
               autoComplete="off"
@@ -185,12 +184,10 @@ export function Combobox({
             ref={listRef}
             id={id ? `${id}-listbox` : undefined}
             role="listbox"
-            className="max-h-60 overflow-y-auto overscroll-contain p-1"
+            className={styles.list}
           >
             {filtered.length === 0 ? (
-              <p className="text-muted-foreground px-2 py-3 text-center text-sm">
-                {emptyMessage}
-              </p>
+              <p className={styles.empty}>{emptyMessage}</p>
             ) : (
               filtered.map((option, index) => {
                 const isSelected = option.value === value;
@@ -202,19 +199,15 @@ export function Combobox({
                     role="option"
                     aria-selected={isSelected}
                     data-combobox-index={index}
-                    className={cn(
-                      "relative flex w-full cursor-default items-center gap-2 rounded-md px-2.5 py-2.5 text-left text-sm outline-hidden transition-colors",
-                      isActive && "bg-accent text-accent-foreground",
-                      isSelected && !isActive && "bg-accent/50",
-                    )}
+                    data-active={isActive ? "" : undefined}
+                    data-selected={isSelected ? "" : undefined}
+                    className={styles.option}
                     onMouseEnter={() => setActiveIndex(index)}
                     onClick={() => selectValue(option.value)}
                   >
-                    <span className="min-w-0 flex-1 truncate">
-                      {option.label}
-                    </span>
+                    <span className={styles.optionLabel}>{option.label}</span>
                     {isSelected ? (
-                      <CheckIcon className="size-4 shrink-0 opacity-70" />
+                      <CheckIcon className={styles.check} aria-hidden="true" />
                     ) : null}
                   </button>
                 );

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import * as React from "react";
+import { CheckIcon, ChevronDownIcon } from "lucide-react";
+
+import { filterComboboxOptions } from "@/lib/bible/filterBooks";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/components/ui/utils";
+
+export type ComboboxOption = {
+  value: string;
+  label: string;
+  /** Extra client-side match terms (aliases, abbreviations, etc.). */
+  keywords?: string[];
+};
+
+export type ComboboxProps = {
+  options: ComboboxOption[];
+  value?: string;
+  onValueChange: (value: string) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+  disabled?: boolean;
+  className?: string;
+  triggerClassName?: string;
+  contentClassName?: string;
+  id?: string;
+  "aria-label"?: string;
+};
+
+/**
+ * Reusable client-side typeahead + dropdown.
+ * Filters options locally by label, value, and optional keywords.
+ */
+export function Combobox({
+  options,
+  value,
+  onValueChange,
+  placeholder = "Select…",
+  searchPlaceholder = "Search…",
+  emptyMessage = "No results.",
+  disabled = false,
+  className,
+  triggerClassName,
+  contentClassName,
+  id,
+  "aria-label": ariaLabel,
+}: ComboboxProps) {
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState("");
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  const searchRef = React.useRef<HTMLInputElement>(null);
+  const listRef = React.useRef<HTMLDivElement>(null);
+
+  const selected = React.useMemo(
+    () => options.find((option) => option.value === value) ?? null,
+    [options, value],
+  );
+
+  const filtered = React.useMemo(
+    () => filterComboboxOptions(options, query),
+    [options, query],
+  );
+
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setQuery("");
+    const selectedIndex = options.findIndex((option) => option.value === value);
+    setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
+    const frame = window.requestAnimationFrame(() => {
+      searchRef.current?.focus();
+    });
+    return () => window.cancelAnimationFrame(frame);
+    // Reset search UI whenever the popover opens.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  React.useEffect(() => {
+    setActiveIndex((prev) => {
+      if (filtered.length === 0) return 0;
+      return Math.min(prev, filtered.length - 1);
+    });
+  }, [filtered.length]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const active = listRef.current?.querySelector<HTMLElement>(
+      `[data-combobox-index="${activeIndex}"]`,
+    );
+    active?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, open, filtered]);
+
+  const selectValue = (next: string) => {
+    onValueChange(next);
+    setOpen(false);
+  };
+
+  const onSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      if (filtered.length === 0) return;
+      setActiveIndex((prev) => (prev + 1) % filtered.length);
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      if (filtered.length === 0) return;
+      setActiveIndex((prev) => (prev - 1 + filtered.length) % filtered.length);
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      const option = filtered[activeIndex];
+      if (option) {
+        selectValue(option.value);
+      }
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div className={cn("w-full min-w-0", className)}>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            id={id}
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            aria-label={ariaLabel}
+            disabled={disabled}
+            className={cn(
+              "border-input data-[placeholder]:text-muted-foreground flex h-9 w-full min-w-0 items-center justify-between gap-2 rounded-md border bg-input-background px-3 py-2 text-sm font-normal whitespace-nowrap shadow-none transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+              !selected && "text-muted-foreground",
+              triggerClassName,
+            )}
+          >
+            <span className="min-w-0 flex-1 truncate text-left">
+              {selected?.label ?? placeholder}
+            </span>
+            <ChevronDownIcon className="size-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          className={cn(
+            "w-[var(--radix-popover-trigger-width)] p-0",
+            contentClassName,
+          )}
+          onOpenAutoFocus={(event) => event.preventDefault()}
+        >
+          <div className="border-b p-2">
+            <Input
+              ref={searchRef}
+              value={query}
+              onChange={(event) => {
+                setQuery(event.target.value);
+                setActiveIndex(0);
+              }}
+              onKeyDown={onSearchKeyDown}
+              placeholder={searchPlaceholder}
+              className="h-10"
+              aria-autocomplete="list"
+              aria-controls={id ? `${id}-listbox` : undefined}
+              autoComplete="off"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+          </div>
+          <div
+            ref={listRef}
+            id={id ? `${id}-listbox` : undefined}
+            role="listbox"
+            className="max-h-60 overflow-y-auto overscroll-contain p-1"
+          >
+            {filtered.length === 0 ? (
+              <p className="text-muted-foreground px-2 py-3 text-center text-sm">
+                {emptyMessage}
+              </p>
+            ) : (
+              filtered.map((option, index) => {
+                const isSelected = option.value === value;
+                const isActive = index === activeIndex;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    role="option"
+                    aria-selected={isSelected}
+                    data-combobox-index={index}
+                    className={cn(
+                      "relative flex w-full cursor-default items-center gap-2 rounded-md px-2.5 py-2.5 text-left text-sm outline-hidden transition-colors",
+                      isActive && "bg-accent text-accent-foreground",
+                      isSelected && !isActive && "bg-accent/50",
+                    )}
+                    onMouseEnter={() => setActiveIndex(index)}
+                    onClick={() => selectValue(option.value)}
+                  >
+                    <span className="min-w-0 flex-1 truncate">
+                      {option.label}
+                    </span>
+                    {isSelected ? (
+                      <CheckIcon className="size-4 shrink-0 opacity-70" />
+                    ) : null}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/lib/bible/bookAliases.ts
+++ b/lib/bible/bookAliases.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared book name → alias list used for speech parsing and typeahead matching.
+ * Keep aliases lowercase; callers should normalise query text the same way.
+ */
+
+export type BookAliasEntry = {
+  name: string;
+  aliases: string[];
+};
+
+const BASE_BOOKS: Array<{ name: string; aliases?: string[] }> = [
+  { name: "Genesis", aliases: ["gen", "genesis"] },
+  { name: "Exodus", aliases: ["ex", "exo", "exodus"] },
+  { name: "Leviticus", aliases: ["lev", "leviticus"] },
+  { name: "Numbers", aliases: ["num", "numbers"] },
+  { name: "Deuteronomy", aliases: ["deut", "deuteronomy"] },
+  { name: "Joshua", aliases: ["josh", "joshua"] },
+  { name: "Judges", aliases: ["judg", "judges"] },
+  { name: "Ruth" },
+  { name: "1 Samuel", aliases: ["1 samuel", "first samuel", "1 sam"] },
+  { name: "2 Samuel", aliases: ["2 samuel", "second samuel", "2 sam"] },
+  { name: "1 Kings", aliases: ["1 kings", "first kings", "1 kgs"] },
+  { name: "2 Kings", aliases: ["2 kings", "second kings", "2 kgs"] },
+  {
+    name: "1 Chronicles",
+    aliases: ["1 chronicles", "first chronicles", "1 chron"],
+  },
+  {
+    name: "2 Chronicles",
+    aliases: ["2 chronicles", "second chronicles", "2 chron"],
+  },
+  { name: "Ezra" },
+  { name: "Nehemiah", aliases: ["neh", "nehemiah"] },
+  { name: "Esther", aliases: ["est", "esther"] },
+  { name: "Job" },
+  { name: "Psalm", aliases: ["psalm", "psalms", "ps"] },
+  { name: "Proverbs", aliases: ["prov", "proverbs"] },
+  { name: "Ecclesiastes", aliases: ["ecclesiastes", "ecc", "eccles"] },
+  {
+    name: "Song of Solomon",
+    aliases: ["song of solomon", "song of songs", "songs"],
+  },
+  { name: "Isaiah", aliases: ["isa", "isaiah"] },
+  { name: "Jeremiah", aliases: ["jer", "jeremiah"] },
+  { name: "Lamentations", aliases: ["lam", "lamentations"] },
+  { name: "Ezekiel", aliases: ["ezek", "ezekiel"] },
+  { name: "Daniel", aliases: ["dan", "daniel"] },
+  { name: "Hosea", aliases: ["hos", "hosea"] },
+  { name: "Joel" },
+  { name: "Amos" },
+  { name: "Obadiah", aliases: ["obadiah", "obad"] },
+  { name: "Jonah", aliases: ["jonah", "jon"] },
+  { name: "Micah", aliases: ["mic", "micah"] },
+  { name: "Nahum", aliases: ["nah", "nahum"] },
+  { name: "Habakkuk", aliases: ["hab", "habakkuk"] },
+  { name: "Zephaniah", aliases: ["zeph", "zephaniah"] },
+  { name: "Haggai", aliases: ["hag", "haggai"] },
+  { name: "Zechariah", aliases: ["zech", "zechariah"] },
+  { name: "Malachi", aliases: ["mal", "malachi"] },
+  { name: "Matthew", aliases: ["matt", "matthew"] },
+  { name: "Mark" },
+  { name: "Luke" },
+  { name: "John" },
+  { name: "Acts", aliases: ["acts", "acts of the apostles"] },
+  { name: "Romans", aliases: ["rom", "romans"] },
+  {
+    name: "1 Corinthians",
+    aliases: ["1 corinthians", "first corinthians", "1 cor"],
+  },
+  {
+    name: "2 Corinthians",
+    aliases: ["2 corinthians", "second corinthians", "2 cor"],
+  },
+  { name: "Galatians", aliases: ["gal", "galatians"] },
+  { name: "Ephesians", aliases: ["eph", "ephesians"] },
+  { name: "Philippians", aliases: ["phil", "philippians"] },
+  { name: "Colossians", aliases: ["col", "colossians"] },
+  {
+    name: "1 Thessalonians",
+    aliases: ["1 thessalonians", "first thessalonians", "1 thess"],
+  },
+  {
+    name: "2 Thessalonians",
+    aliases: ["2 thessalonians", "second thessalonians", "2 thess"],
+  },
+  { name: "1 Timothy", aliases: ["1 timothy", "first timothy", "1 tim"] },
+  { name: "2 Timothy", aliases: ["2 timothy", "second timothy", "2 tim"] },
+  { name: "Titus" },
+  { name: "Philemon", aliases: ["philem", "philemon"] },
+  { name: "Hebrews", aliases: ["heb", "hebrews"] },
+  { name: "James", aliases: ["jam", "james"] },
+  { name: "1 Peter", aliases: ["1 peter", "first peter", "1 pet"] },
+  { name: "2 Peter", aliases: ["2 peter", "second peter", "2 pet"] },
+  { name: "1 John", aliases: ["1 john", "first john", "1 jn"] },
+  { name: "2 John", aliases: ["2 john", "second john", "2 jn"] },
+  { name: "3 John", aliases: ["3 john", "third john", "3 jn"] },
+  { name: "Jude" },
+  { name: "Revelation", aliases: ["rev", "revelation", "revelations"] },
+];
+
+function buildAliases(name: string, extras?: string[]): string[] {
+  const aliasSet = new Set<string>([name.toLowerCase()]);
+
+  if (extras) {
+    extras.forEach((alias) => aliasSet.add(alias.toLowerCase()));
+  }
+
+  if (/^[1-3]/.test(name)) {
+    const parts = name.split(" ");
+    const number = parts[0];
+    const rest = parts.slice(1).join(" ");
+    const ordinal =
+      number === "1" ? "first" : number === "2" ? "second" : "third";
+    aliasSet.add(`${number} ${rest}`.toLowerCase());
+    aliasSet.add(`${ordinal} ${rest}`.toLowerCase());
+  }
+
+  return Array.from(aliasSet).sort((a, b) => b.length - a.length);
+}
+
+export const BOOK_ALIASES: BookAliasEntry[] = BASE_BOOKS.map(
+  ({ name, aliases }) => ({
+    name,
+    aliases: buildAliases(name, aliases),
+  }),
+);
+
+const ALIASES_BY_NAME = new Map(
+  BOOK_ALIASES.map((entry) => [entry.name.toLowerCase(), entry.aliases]),
+);
+
+/** Returns lowercase aliases for a canonical book name (empty if unknown). */
+export function getAliasesForBookName(name: string): string[] {
+  return ALIASES_BY_NAME.get(name.toLowerCase()) ?? [name.toLowerCase()];
+}

--- a/lib/bible/filterBooks.ts
+++ b/lib/bible/filterBooks.ts
@@ -1,0 +1,78 @@
+import { getAliasesForBookName } from "./bookAliases";
+import type { BibleBookSummary } from "@/types/bible";
+
+export type BookSearchable = Pick<
+  BibleBookSummary,
+  "id" | "name" | "abbreviation"
+>;
+
+export type ComboboxFilterOption = {
+  value: string;
+  label: string;
+  keywords?: string[];
+};
+
+const normaliseQuery = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+/**
+ * Client-side filter for generic combobox options (label + optional keywords).
+ */
+export function filterComboboxOptions<T extends ComboboxFilterOption>(
+  options: T[],
+  query: string,
+): T[] {
+  const needle = normaliseQuery(query);
+  if (!needle) {
+    return options;
+  }
+
+  return options.filter((option) => {
+    const haystacks = [
+      option.label,
+      option.value,
+      ...(option.keywords ?? []),
+    ].map(normaliseQuery);
+
+    return haystacks.some(
+      (haystack) =>
+        haystack.includes(needle) ||
+        haystack.split(" ").some((token) => token.startsWith(needle)),
+    );
+  });
+}
+
+/**
+ * Build searchable keywords for a Bible book (name, abbreviation, aliases).
+ */
+export function getBookSearchKeywords(
+  book: Pick<BibleBookSummary, "name" | "abbreviation">,
+): string[] {
+  const keywords = new Set<string>(getAliasesForBookName(book.name));
+  if (book.abbreviation) {
+    keywords.add(book.abbreviation.toLowerCase());
+  }
+  return Array.from(keywords);
+}
+
+/**
+ * Client-side book typeahead filter. Matches name, abbreviation, and aliases
+ * (e.g. "gen" → Genesis, "1 cor" → 1 Corinthians).
+ */
+export function filterBooks<T extends BookSearchable>(
+  books: T[],
+  query: string,
+): T[] {
+  const options = books.map((book) => ({
+    value: book.id,
+    label: book.name,
+    keywords: getBookSearchKeywords(book),
+    book,
+  }));
+
+  return filterComboboxOptions(options, query).map((option) => option.book);
+}

--- a/lib/bible/parseReferenceFromText.ts
+++ b/lib/bible/parseReferenceFromText.ts
@@ -1,3 +1,8 @@
+import {
+  BOOK_ALIASES,
+  type BookAliasEntry,
+} from "./bookAliases";
+
 export type ParsedReference = {
   book: string | null;
   chapter: number | null;
@@ -6,102 +11,7 @@ export type ParsedReference = {
   bodyText: string;
 };
 
-type BookAlias = {
-  name: string;
-  aliases: string[];
-};
-
-const BASE_BOOKS: Array<{ name: string; aliases?: string[] }> = [
-  { name: "Genesis", aliases: ["gen", "genesis"] },
-  { name: "Exodus", aliases: ["ex", "exo", "exodus"] },
-  { name: "Leviticus", aliases: ["lev", "leviticus"] },
-  { name: "Numbers", aliases: ["num", "numbers"] },
-  { name: "Deuteronomy", aliases: ["deut", "deuteronomy"] },
-  { name: "Joshua", aliases: ["josh", "joshua"] },
-  { name: "Judges", aliases: ["judg", "judges"] },
-  { name: "Ruth" },
-  { name: "1 Samuel", aliases: ["1 samuel", "first samuel", "1 sam"] },
-  { name: "2 Samuel", aliases: ["2 samuel", "second samuel", "2 sam"] },
-  { name: "1 Kings", aliases: ["1 kings", "first kings", "1 kgs"] },
-  { name: "2 Kings", aliases: ["2 kings", "second kings", "2 kgs"] },
-  { name: "1 Chronicles", aliases: ["1 chronicles", "first chronicles", "1 chron"] },
-  { name: "2 Chronicles", aliases: ["2 chronicles", "second chronicles", "2 chron"] },
-  { name: "Ezra" },
-  { name: "Nehemiah", aliases: ["neh", "nehemiah"] },
-  { name: "Esther", aliases: ["est", "esther"] },
-  { name: "Job" },
-  { name: "Psalm", aliases: ["psalm", "psalms", "ps"] },
-  { name: "Proverbs", aliases: ["prov", "proverbs"] },
-  { name: "Ecclesiastes", aliases: ["ecclesiastes", "ecc", "eccles"] },
-  { name: "Song of Solomon", aliases: ["song of solomon", "song of songs", "songs"] },
-  { name: "Isaiah", aliases: ["isa", "isaiah"] },
-  { name: "Jeremiah", aliases: ["jer", "jeremiah"] },
-  { name: "Lamentations", aliases: ["lam", "lamentations"] },
-  { name: "Ezekiel", aliases: ["ezek", "ezekiel"] },
-  { name: "Daniel", aliases: ["dan", "daniel"] },
-  { name: "Hosea", aliases: ["hos", "hosea"] },
-  { name: "Joel" },
-  { name: "Amos" },
-  { name: "Obadiah", aliases: ["obadiah", "obad"] },
-  { name: "Jonah", aliases: ["jonah", "jon"] },
-  { name: "Micah", aliases: ["mic", "micah"] },
-  { name: "Nahum", aliases: ["nah", "nahum"] },
-  { name: "Habakkuk", aliases: ["hab", "habakkuk"] },
-  { name: "Zephaniah", aliases: ["zeph", "zephaniah"] },
-  { name: "Haggai", aliases: ["hag", "haggai"] },
-  { name: "Zechariah", aliases: ["zech", "zechariah"] },
-  { name: "Malachi", aliases: ["mal", "malachi"] },
-  { name: "Matthew", aliases: ["matt", "matthew"] },
-  { name: "Mark" },
-  { name: "Luke" },
-  { name: "John" },
-  { name: "Acts", aliases: ["acts", "acts of the apostles"] },
-  { name: "Romans", aliases: ["rom", "romans"] },
-  { name: "1 Corinthians", aliases: ["1 corinthians", "first corinthians", "1 cor"] },
-  { name: "2 Corinthians", aliases: ["2 corinthians", "second corinthians", "2 cor"] },
-  { name: "Galatians", aliases: ["gal", "galatians"] },
-  { name: "Ephesians", aliases: ["eph", "ephesians"] },
-  { name: "Philippians", aliases: ["phil", "philippians"] },
-  { name: "Colossians", aliases: ["col", "colossians"] },
-  { name: "1 Thessalonians", aliases: ["1 thessalonians", "first thessalonians", "1 thess"] },
-  { name: "2 Thessalonians", aliases: ["2 thessalonians", "second thessalonians", "2 thess"] },
-  { name: "1 Timothy", aliases: ["1 timothy", "first timothy", "1 tim"] },
-  { name: "2 Timothy", aliases: ["2 timothy", "second timothy", "2 tim"] },
-  { name: "Titus" },
-  { name: "Philemon", aliases: ["philem", "philemon"] },
-  { name: "Hebrews", aliases: ["heb", "hebrews"] },
-  { name: "James", aliases: ["jam", "james"] },
-  { name: "1 Peter", aliases: ["1 peter", "first peter", "1 pet"] },
-  { name: "2 Peter", aliases: ["2 peter", "second peter", "2 pet"] },
-  { name: "1 John", aliases: ["1 john", "first john", "1 jn"] },
-  { name: "2 John", aliases: ["2 john", "second john", "2 jn"] },
-  { name: "3 John", aliases: ["3 john", "third john", "3 jn"] },
-  { name: "Jude" },
-  { name: "Revelation", aliases: ["rev", "revelation", "revelations"] },
-];
-
-const BOOKS: BookAlias[] = BASE_BOOKS.map(({ name, aliases }) => {
-  const baseAlias = name.toLowerCase();
-  const aliasSet = new Set<string>([baseAlias]);
-
-  if (aliases) {
-    aliases.forEach((alias) => aliasSet.add(alias.toLowerCase()));
-  }
-
-  if (/^[1-3]/.test(name)) {
-    const parts = name.split(" ");
-    const number = parts[0];
-    const rest = parts.slice(1).join(" ");
-    const ordinal = number === "1" ? "first" : number === "2" ? "second" : "third";
-    aliasSet.add(`${number} ${rest}`.toLowerCase());
-    aliasSet.add(`${ordinal} ${rest}`.toLowerCase());
-  }
-
-  return {
-    name,
-    aliases: Array.from(aliasSet).sort((a, b) => b.length - a.length),
-  };
-});
+const BOOKS: BookAliasEntry[] = BOOK_ALIASES;
 
 const NUMBER_WORDS: Record<string, number> = {
   zero: 0,
@@ -210,7 +120,7 @@ export const parseReferenceFromText = (transcript: string): ParsedReference => {
   const lower = normaliseText(original);
   const originalLower = original.toLowerCase();
 
-  let matchedBook: BookAlias | null = null;
+  let matchedBook: BookAliasEntry | null = null;
   let matchedAlias: string | null = null;
   let matchIndex = Number.POSITIVE_INFINITY;
 

--- a/lib/bible/verseRange.ts
+++ b/lib/bible/verseRange.ts
@@ -1,0 +1,30 @@
+export function formatVerseRange(start: number, end: number): string {
+  if (start === end) {
+    return String(start);
+  }
+  return `${start}-${end}`;
+}
+
+export function parseVerseRangeValue(
+  value: string,
+): { start: number; end: number } | null {
+  const normalized = value.trim();
+  if (!normalized) {
+    return null;
+  }
+  const match = normalized.match(/^(\d+)(?:\s*-\s*(\d+))?$/);
+  if (!match) {
+    return null;
+  }
+  const start = Number(match[1]);
+  const end = match[2] ? Number(match[2]) : start;
+  if (
+    !Number.isFinite(start) ||
+    !Number.isFinite(end) ||
+    start <= 0 ||
+    end < start
+  ) {
+    return null;
+  }
+  return { start, end };
+}

--- a/lib/study/week.ts
+++ b/lib/study/week.ts
@@ -33,6 +33,16 @@ const parseYmd = (ymd: string): { year: number; month: number; day: number } => 
   };
 };
 
+const toUtcNoon = (ymd: string): Date => {
+  const { year, month, day } = parseYmd(ymd);
+  return new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+};
+
+const formatYmdFromUtc = (date: Date): string =>
+  `${date.getUTCFullYear()}-${pad2(date.getUTCMonth() + 1)}-${pad2(
+    date.getUTCDate(),
+  )}`;
+
 /** Monday (ISO) of the week containing `input`, as YYYY-MM-DD in `timeZone`. */
 export function startOfWeek(
   input: Date = new Date(),
@@ -45,18 +55,61 @@ export function startOfWeek(
   const weekday = utcNoon.getUTCDay(); // 0 Sun .. 6 Sat
   const daysFromMonday = (weekday + 6) % 7;
   utcNoon.setUTCDate(utcNoon.getUTCDate() - daysFromMonday);
-  return `${utcNoon.getUTCFullYear()}-${pad2(utcNoon.getUTCMonth() + 1)}-${pad2(
-    utcNoon.getUTCDate(),
-  )}`;
+  return formatYmdFromUtc(utcNoon);
 }
 
 export function weekEndFromStart(weekStart: string): string {
-  const { year, month, day } = parseYmd(weekStart);
-  const monday = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+  const monday = toUtcNoon(weekStart);
   monday.setUTCDate(monday.getUTCDate() + 6);
-  return `${monday.getUTCFullYear()}-${pad2(monday.getUTCMonth() + 1)}-${pad2(
-    monday.getUTCDate(),
-  )}`;
+  return formatYmdFromUtc(monday);
+}
+
+/** Shift a Monday `weekStart` by `deltaWeeks` (negative = earlier). */
+export function shiftWeek(weekStart: string, deltaWeeks: number): string {
+  const monday = toUtcNoon(weekStart);
+  monday.setUTCDate(monday.getUTCDate() + deltaWeeks * 7);
+  return formatYmdFromUtc(monday);
+}
+
+export type WeekDay = {
+  ymd: string;
+  dayOfMonth: number;
+  weekdayShort: string;
+  weekdayLong: string;
+  isToday: boolean;
+};
+
+const WEEKDAY_SHORT = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+const WEEKDAY_LONG = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+] as const;
+
+/** Seven days (Mon–Sun) for a week starting on `weekStart`. */
+export function daysOfWeek(
+  weekStart: string,
+  now = new Date(),
+  timeZone = DEFAULT_TIME_ZONE,
+): WeekDay[] {
+  const todayYmd = ymdInTimeZone(now, timeZone);
+  const monday = toUtcNoon(weekStart);
+  return WEEKDAY_SHORT.map((weekdayShort, index) => {
+    const day = new Date(monday);
+    day.setUTCDate(monday.getUTCDate() + index);
+    const ymd = formatYmdFromUtc(day);
+    return {
+      ymd,
+      dayOfMonth: day.getUTCDate(),
+      weekdayShort,
+      weekdayLong: WEEKDAY_LONG[index],
+      isToday: ymd === todayYmd,
+    };
+  });
 }
 
 /** Visibility window: Monday 00:00 local through next Monday 00:00 (exclusive end as ISO). */
@@ -103,4 +156,84 @@ export function formatWeekLabel(weekStart: string): string {
     day: "numeric",
   });
   return `${fmt.format(startDate)} – ${fmt.format(endDate)}`;
+}
+
+/** Longer range label, e.g. "Jul 13 – Jul 19, 2026". */
+export function formatWeekRangeDetailed(weekStart: string): string {
+  const end = weekEndFromStart(weekStart);
+  const startDate = new Date(`${weekStart}T12:00:00`);
+  const endDate = new Date(`${end}T12:00:00`);
+  const sameYear = startDate.getFullYear() === endDate.getFullYear();
+  const startFmt = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
+  });
+  const endFmt = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+  return `${startFmt.format(startDate)} – ${endFmt.format(endDate)}`;
+}
+
+/** First day of month as YYYY-MM-DD (calendar month containing `ymd`). */
+export function startOfMonth(ymd: string): string {
+  const { year, month } = parseYmd(ymd);
+  return `${year}-${pad2(month)}-01`;
+}
+
+export function shiftMonth(monthStart: string, deltaMonths: number): string {
+  const { year, month } = parseYmd(monthStart);
+  const date = new Date(Date.UTC(year, month - 1 + deltaMonths, 1, 12, 0, 0));
+  return formatYmdFromUtc(date);
+}
+
+/** Today's calendar date as YYYY-MM-DD in `timeZone`. */
+export function todayYmd(
+  now = new Date(),
+  timeZone = DEFAULT_TIME_ZONE,
+): string {
+  return ymdInTimeZone(now, timeZone);
+}
+
+export type CalendarDay = {
+  ymd: string;
+  dayOfMonth: number;
+  inMonth: boolean;
+  weekStart: string;
+};
+
+/**
+ * Monday-start month grid covering `monthStart` (YYYY-MM-01).
+ * Includes leading/trailing days so every row is a full Mon–Sun week.
+ */
+export function buildMonthWeeks(monthStart: string): CalendarDay[][] {
+  const { year, month } = parseYmd(monthStart);
+  const firstOfMonth = `${year}-${pad2(month)}-01`;
+  const gridStart = startOfWeek(new Date(`${firstOfMonth}T12:00:00`));
+  const cursor = toUtcNoon(gridStart);
+  const weeks: CalendarDay[][] = [];
+
+  for (let week = 0; week < 6; week += 1) {
+    const row: CalendarDay[] = [];
+    for (let day = 0; day < 7; day += 1) {
+      const ymd = formatYmdFromUtc(cursor);
+      const cellWeekStart = startOfWeek(new Date(`${ymd}T12:00:00`));
+      row.push({
+        ymd,
+        dayOfMonth: cursor.getUTCDate(),
+        inMonth: cursor.getUTCMonth() + 1 === month,
+        weekStart: cellWeekStart,
+      });
+      cursor.setUTCDate(cursor.getUTCDate() + 1);
+    }
+    weeks.push(row);
+    if (week >= 3 && row.every((cell) => !cell.inMonth)) {
+      weeks.pop();
+      break;
+    }
+  }
+
+  return weeks;
 }

--- a/tests/filterBooks.test.mjs
+++ b/tests/filterBooks.test.mjs
@@ -1,0 +1,91 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { loadTsModule } from "./utils/load-ts-module.mjs";
+
+const loadFilter = async () => {
+  const mod = await loadTsModule("lib/bible/filterBooks.ts");
+  return {
+    filterBooks: mod.filterBooks,
+    filterComboboxOptions: mod.filterComboboxOptions,
+  };
+};
+
+const sampleBooks = [
+  {
+    id: "gen",
+    name: "Genesis",
+    abbreviation: "Gen",
+    chapters: 50,
+    order: 1,
+  },
+  {
+    id: "john",
+    name: "John",
+    abbreviation: "Jn",
+    chapters: 21,
+    order: 43,
+  },
+  {
+    id: "1cor",
+    name: "1 Corinthians",
+    abbreviation: "1 Cor",
+    chapters: 16,
+    order: 46,
+  },
+  {
+    id: "rev",
+    name: "Revelation",
+    abbreviation: "Rev",
+    chapters: 22,
+    order: 66,
+  },
+];
+
+describe("filterBooks", () => {
+  it("returns all books for an empty query", async () => {
+    const { filterBooks } = await loadFilter();
+    assert.equal(filterBooks(sampleBooks, "").length, sampleBooks.length);
+    assert.equal(filterBooks(sampleBooks, "   ").length, sampleBooks.length);
+  });
+
+  it("matches by name prefix and abbreviation", async () => {
+    const { filterBooks } = await loadFilter();
+    assert.deepEqual(
+      filterBooks(sampleBooks, "gen").map((book) => book.name),
+      ["Genesis"],
+    );
+    assert.deepEqual(
+      filterBooks(sampleBooks, "jn").map((book) => book.name),
+      ["John"],
+    );
+  });
+
+  it("matches numbered book aliases", async () => {
+    const { filterBooks } = await loadFilter();
+    assert.deepEqual(
+      filterBooks(sampleBooks, "1 cor").map((book) => book.name),
+      ["1 Corinthians"],
+    );
+    assert.deepEqual(
+      filterBooks(sampleBooks, "first corinthians").map((book) => book.name),
+      ["1 Corinthians"],
+    );
+  });
+});
+
+describe("filterComboboxOptions", () => {
+  it("filters by label and keywords", async () => {
+    const { filterComboboxOptions } = await loadFilter();
+    const options = [
+      { value: "1", label: "Chapter 1", keywords: ["1"] },
+      { value: "15", label: "Chapter 15", keywords: ["15"] },
+      { value: "50", label: "Chapter 50", keywords: ["50"] },
+    ];
+
+    assert.deepEqual(
+      filterComboboxOptions(options, "15").map((option) => option.value),
+      ["15"],
+    );
+  });
+});

--- a/tests/studyWeek.test.mjs
+++ b/tests/studyWeek.test.mjs
@@ -9,6 +9,10 @@ const {
   isCurrentWeek,
   formatWeekLabel,
   weekVisibilityWindow,
+  shiftWeek,
+  daysOfWeek,
+  formatWeekRangeDetailed,
+  buildMonthWeeks,
 } = await loadTsModule("lib/study/week.ts");
 
 test("startOfWeek returns Monday for a Wednesday", () => {
@@ -38,4 +42,37 @@ test("formatWeekLabel is human readable", () => {
   const label = formatWeekLabel("2026-07-13");
   assert.match(label, /Jul/);
   assert.match(label, /–/);
+});
+
+test("shiftWeek moves by seven-day blocks", () => {
+  assert.equal(shiftWeek("2026-07-13", 1), "2026-07-20");
+  assert.equal(shiftWeek("2026-07-13", -1), "2026-07-06");
+});
+
+test("daysOfWeek returns Mon-Sun for a week", () => {
+  const days = daysOfWeek("2026-07-13", new Date("2026-07-15T15:00:00Z"));
+  assert.equal(days.length, 7);
+  assert.equal(days[0].weekdayShort, "Mon");
+  assert.equal(days[0].ymd, "2026-07-13");
+  assert.equal(days[6].ymd, "2026-07-19");
+  assert.equal(days[2].isToday, true); // Wednesday Jul 15
+});
+
+test("formatWeekRangeDetailed includes the year", () => {
+  const label = formatWeekRangeDetailed("2026-07-13");
+  assert.match(label, /Jul 13/);
+  assert.match(label, /Jul 19/);
+  assert.match(label, /2026/);
+});
+
+test("buildMonthWeeks returns full Mon-Sun rows", () => {
+  const weeks = buildMonthWeeks("2026-07-01");
+  assert.ok(weeks.length >= 4);
+  for (const week of weeks) {
+    assert.equal(week.length, 7);
+    assert.equal(week[0].weekStart, week[0].ymd);
+  }
+  const mid = weeks.find((week) => week.some((day) => day.ymd === "2026-07-15"));
+  assert.ok(mid);
+  assert.equal(mid[0].ymd, "2026-07-13");
 });

--- a/tests/utils/load-ts-module.mjs
+++ b/tests/utils/load-ts-module.mjs
@@ -16,22 +16,93 @@ const COMPILER_OPTIONS = {
   esModuleInterop: true,
 };
 
-export const loadTsModule = async (relativePath) => {
-  const absolutePath = path.resolve(ROOT_DIR, relativePath);
-  const source = await readFile(absolutePath, "utf8");
+const IMPORT_RE =
+  /(?<=(?:^|\n)import\s+(?!type\b)[^"'`]*?\sfrom\s+)["'](@\/[^"']+|\.{1,2}\/[^"']+)["']/g;
 
-  const transpiled = ts.transpileModule(source, {
-    compilerOptions: COMPILER_OPTIONS,
-    fileName: path.basename(relativePath),
+const resolveImportPath = (fromFile, specifier) => {
+  if (specifier.startsWith("@/")) {
+    return path.resolve(ROOT_DIR, specifier.slice(2));
+  }
+  return path.resolve(path.dirname(fromFile), specifier);
+};
+
+const withTsExtension = (absolutePath) => {
+  if (absolutePath.endsWith(".ts") || absolutePath.endsWith(".tsx")) {
+    return absolutePath;
+  }
+  return `${absolutePath}.ts`;
+};
+
+/**
+ * Transpile a TS module and recursively rewrite local/@ imports to data URLs
+ * so node:test can load split modules without a bundler.
+ */
+export const loadTsModule = async (relativePath, cache = new Map()) => {
+  const loaded = await loadTsModuleEntry(relativePath, cache);
+  return loaded.module;
+};
+
+const loadTsModuleEntry = async (relativePath, cache) => {
+  const absolutePath = withTsExtension(path.resolve(ROOT_DIR, relativePath));
+
+  if (cache.has(absolutePath)) {
+    return cache.get(absolutePath);
+  }
+
+  let settle;
+  const pending = new Promise((resolve, reject) => {
+    settle = { resolve, reject };
   });
+  // Store the promise so concurrent loads share one build.
+  cache.set(absolutePath, pending);
 
-  const moduleUrl = new URL(
-    `data:text/javascript;base64,${Buffer.from(transpiled.outputText).toString(
-      "base64"
-    )}`
-  );
+  try {
+    let source = await readFile(absolutePath, "utf8");
+    source = source.replace(/^import\s+type\s+[^;]+;?\s*$/gm, "");
 
-  return import(moduleUrl.href, {
-    assert: { type: "javascript" },
-  });
+    const specifiers = [...source.matchAll(IMPORT_RE)].map((match) => match[1]);
+    const rewrittenSpecifiers = new Map();
+
+    for (const specifier of specifiers) {
+      const depAbsolute = withTsExtension(
+        resolveImportPath(absolutePath, specifier)
+      );
+      const depEntry = await loadTsModuleEntry(
+        path.relative(ROOT_DIR, depAbsolute),
+        cache
+      );
+      rewrittenSpecifiers.set(specifier, depEntry.moduleUrl);
+    }
+
+    let rewrittenSource = source;
+    for (const [specifier, moduleUrl] of rewrittenSpecifiers) {
+      rewrittenSource = rewrittenSource.replaceAll(
+        `"${specifier}"`,
+        `"${moduleUrl}"`
+      );
+      rewrittenSource = rewrittenSource.replaceAll(
+        `'${specifier}'`,
+        `"${moduleUrl}"`
+      );
+    }
+
+    const transpiled = ts.transpileModule(rewrittenSource, {
+      compilerOptions: COMPILER_OPTIONS,
+      fileName: path.basename(absolutePath),
+    });
+
+    const moduleUrl = `data:text/javascript;base64,${Buffer.from(
+      transpiled.outputText
+    ).toString("base64")}`;
+
+    const imported = await import(moduleUrl);
+    const entry = { module: imported, moduleUrl };
+    cache.set(absolutePath, entry);
+    settle.resolve(entry);
+    return entry;
+  } catch (error) {
+    cache.delete(absolutePath);
+    settle.reject(error);
+    throw error;
+  }
 };

--- a/tests/verseRangePicker.test.mjs
+++ b/tests/verseRangePicker.test.mjs
@@ -1,0 +1,28 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { loadTsModule } from "./utils/load-ts-module.mjs";
+
+const loadHelpers = async () => {
+  const mod = await loadTsModule("lib/bible/verseRange.ts");
+  return {
+    formatVerseRange: mod.formatVerseRange,
+    parseVerseRangeValue: mod.parseVerseRangeValue,
+  };
+};
+
+describe("verseRange helpers", () => {
+  it("formats single and ranged verses", async () => {
+    const { formatVerseRange } = await loadHelpers();
+    assert.equal(formatVerseRange(5, 5), "5");
+    assert.equal(formatVerseRange(1, 26), "1-26");
+  });
+
+  it("parses verse range strings", async () => {
+    const { parseVerseRangeValue } = await loadHelpers();
+    assert.deepEqual(parseVerseRangeValue("1-26"), { start: 1, end: 26 });
+    assert.deepEqual(parseVerseRangeValue("5"), { start: 5, end: 5 });
+    assert.equal(parseVerseRangeValue(""), null);
+    assert.equal(parseVerseRangeValue("nope"), null);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Aligns member **Study** (`/pre-read`) and **Reflections** controls with the admin Realign button/input language, and cleans up Reflections page metadata.

### Changes
- Shared `components/realign/controls.module.css` (cream inputs, larger mobile tap targets, red→orange primary buttons)
- Pre-read: comments, poll votes, Join Stream CTA
- Reflections: search/create/edit/audio-note controls
- Removed Reflections header meta, stats cards, and create-dialog meta tiles

## Test plan
- [ ] `/pre-read` — comment textarea/post + poll vote buttons match admin sizing/style
- [ ] `/dashboard/notes` — header is title-only (no meta line/stats)
- [ ] Create/edit/record note modals use Realign inputs + primary/secondary buttons

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6b08-f355-774b-a220-b958a42745b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6b08-f355-774b-a220-b958a42745b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

