### PR TITLE
Fix Pre-Read mobile horizontal overflow

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -369,9 +369,15 @@
     border-color: var(--border);
   }
 
+  html {
+    overflow-x: clip;
+  }
+
   body {
     background-color: var(--background);
     color: var(--foreground);
+    overflow-x: clip;
+    max-width: 100%;
   }
 }
 

--- a/app/pre-read/PreReadPage.module.css
+++ b/app/pre-read/PreReadPage.module.css
@@ -1,6 +1,8 @@
 .page {
+  box-sizing: border-box;
   width: 100%;
-  max-width: 720px;
+  max-width: min(720px, 100%);
+  min-width: 0;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -10,6 +12,7 @@
   z-index: 0;
   padding: 1rem 1rem 2.5rem;
   background: #fff5f0;
+  overflow-x: clip;
 }
 
 .topBar {
@@ -17,6 +20,8 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
+  min-width: 0;
+  max-width: 100%;
   position: sticky;
   top: 0;
   z-index: 10;
@@ -47,6 +52,7 @@
 
 .brandMark {
   margin: 0;
+  flex-shrink: 0;
   font-size: 1rem;
   font-weight: 800;
   letter-spacing: -0.02em;
@@ -57,6 +63,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  min-width: 0;
+  max-width: 100%;
   padding: 0.25rem 0.15rem 0.5rem;
 }
 
@@ -67,6 +75,7 @@
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: #4a4a4a;
+  overflow-wrap: anywhere;
 }
 
 .heroTitle {
@@ -75,6 +84,8 @@
   font-weight: 750;
   line-height: 1.15;
   color: #1a1a1a;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .scriptureRow {
@@ -82,13 +93,19 @@
   flex-wrap: wrap;
   align-items: center;
   gap: 0.65rem 1rem;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .scriptureRef {
   margin: 0;
+  min-width: 0;
+  max-width: 100%;
   font-size: 1.05rem;
   font-weight: 700;
   color: #d91f26;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .heroLink {
@@ -115,21 +132,33 @@
   font-size: 1.02rem;
   line-height: 1.7;
   color: #1a1a1a;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .section {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   border-radius: 1rem;
   border: 1px solid #e8cfc4;
   background: #ffffff;
   box-shadow: 0 8px 28px color-mix(in oklab, #d91f26 7%, transparent);
   padding: 1.15rem 1.2rem;
+  overflow-wrap: anywhere;
 }
 
 .sectionMuted {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   border-radius: 1rem;
   border: 1px solid #e8cfc4;
   background: color-mix(in oklab, #ffe8dc 35%, #ffffff);
   padding: 1.15rem 1.2rem;
+  overflow-wrap: anywhere;
 }
 
 .sectionEyebrow {
@@ -142,6 +171,10 @@
 }
 
 .memoryCard {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   border-radius: 1rem;
   border: 1px solid color-mix(in oklab, #d91f26 25%, #e8cfc4);
   background: linear-gradient(
@@ -151,6 +184,7 @@
   );
   box-shadow: 0 12px 32px color-mix(in oklab, #d91f26 12%, transparent);
   padding: 1.35rem 1.25rem;
+  overflow-wrap: anywhere;
 }
 
 .memoryQuote {
@@ -160,6 +194,8 @@
   font-weight: 600;
   line-height: 1.45;
   color: #1a1a1a;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .memoryReference {
@@ -188,12 +224,17 @@
 }
 
 .reflectionItem {
+  box-sizing: border-box;
+  min-width: 0;
+  max-width: 100%;
   border-radius: 0.85rem;
   border: 1px solid #e8cfc4;
   background: #fff8f4;
   padding: 0.9rem 1rem;
   font-size: 0.95rem;
   line-height: 1.5;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .reflectionBadge {
@@ -288,6 +329,11 @@
   display: flex;
   flex-direction: column;
   gap: 0.65rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.materialsList > li {
   min-width: 0;
   max-width: 100%;
 }

--- a/components/pre-read/CommentsSection.module.css
+++ b/components/pre-read/CommentsSection.module.css
@@ -1,4 +1,8 @@
 .card {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   border-radius: 1rem;
   border: 1px solid #e8cfc4;
   background: #ffffff;
@@ -7,6 +11,8 @@
   display: flex;
   flex-direction: column;
   gap: 1.15rem;
+  overflow-x: clip;
+  overflow-wrap: anywhere;
 }
 
 .header {

--- a/components/pre-read/PollWidget.module.css
+++ b/components/pre-read/PollWidget.module.css
@@ -1,4 +1,8 @@
 .card {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   border-radius: 1rem;
   border: 1px solid #e8cfc4;
   background: #ffffff;
@@ -7,6 +11,8 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  overflow-x: clip;
+  overflow-wrap: anywhere;
 }
 
 .header {

--- a/components/pre-read/ScripturePassagePager.module.css
+++ b/components/pre-read/ScripturePassagePager.module.css
@@ -1,4 +1,8 @@
 .card {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   border-radius: 1rem;
   border: 1px solid #e8cfc4;
   background: #ffffff;
@@ -7,6 +11,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
+  overflow-x: clip;
+  overflow-wrap: anywhere;
 }
 
 .eyebrow {
@@ -37,6 +43,10 @@
 }
 
 .scrollPane {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   max-height: min(22rem, 48vh);
   overflow-x: hidden;
   overflow-y: auto;
@@ -60,6 +70,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .verseItem {
@@ -87,4 +99,5 @@
   line-height: 1.65;
   color: #1a1a1a;
   overflow-wrap: anywhere;
+  word-break: break-word;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
The Pre-Read (Study) screen still overflowed horizontally on mobile after the recent staging fix. Symptoms matched the screenshot: right card edges flush to the viewport, `SWORD` clipped in the sticky header, and asymmetric left/right padding.

The previous patch only tightened materials list and verse `min-width`/`overflow-wrap`. It did not clamp the page flex column or section cards, so flex items with default `min-width: auto` could still expand the document width.

## Fix
- Clamp `.page` with `box-sizing`, `min-width: 0`, `max-width: min(720px, 100%)`, and `overflow-x: clip`
- Apply the same containment pattern used in admin StudyHubPreview to sections, scripture pager, poll, and comments cards
- Force long titles/summary/scripture/reflection text to wrap with `overflow-wrap: anywhere` / `word-break: break-word`
- Keep the brand mark from shrinking, and clip document-level horizontal overflow on `html`/`body`

## Test plan
- [ ] Open `/pre-read` on a narrow phone (~390px) or Safari responsive mode
- [ ] Confirm no horizontal scroll; equal left/right padding on cards
- [ ] Confirm sticky `SWORD` and `Today` back link are fully visible
- [ ] Scroll scripture pane vertically; text wraps instead of widening the page
- [ ] Check materials, memory verse, reflections, poll, and comments still layout correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fab00-cb64-7951-a1f1-89452a0503e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fab00-cb64-7951-a1f1-89452a0503e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

