### PR TITLE
Fix slim admin buttons and mobile header overlap

### DIFF
--- a/app/(admin)/admin/quizzes/QuizForm.module.css
+++ b/app/(admin)/admin/quizzes/QuizForm.module.css
@@ -479,3 +479,81 @@ textarea.control {
     grid-template-columns: minmax(0, 1fr);
   }
 }
+
+@media (max-width: 719px) {
+  .toolbar {
+    padding: 1.1rem 1rem;
+  }
+
+  .toolbarActions {
+    width: 100%;
+  }
+
+  .toolbarActions :global(button) {
+    flex: 1 1 calc(50% - 0.4rem);
+    min-height: 3.5rem;
+    height: auto;
+    padding-block: 0.85rem;
+  }
+
+  .section {
+    padding: 1.1rem 1rem;
+  }
+
+  .sectionHeaderRow {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sectionHeaderRow :global(button) {
+    width: 100%;
+    min-height: 3.5rem;
+    height: auto;
+    padding-block: 0.85rem;
+  }
+
+  .control {
+    min-height: 3.5rem;
+    font-size: 1.05rem;
+    padding: 0.85rem 1rem;
+  }
+
+  textarea.control {
+    min-height: 9rem;
+  }
+
+  .chip {
+    min-height: 3rem;
+    padding: 0.65rem 1rem;
+    font-size: 0.95rem;
+  }
+
+  .countStepperButton {
+    width: 3.5rem;
+    height: 3.5rem;
+  }
+
+  .countResetButton {
+    min-height: 3.5rem;
+    padding: 0.65rem 1rem;
+  }
+
+  .formShell :global(button:not([role="combobox"])) {
+    min-height: 3.5rem;
+  }
+
+  .formShell :global(button[role="combobox"]) {
+    min-height: 3.5rem;
+  }
+
+  .generateButton {
+    min-height: 3.5rem !important;
+    padding: 0.9rem 1.25rem !important;
+  }
+
+  .questionHeader :global(button) {
+    min-height: 3rem;
+    height: auto;
+    padding-block: 0.65rem;
+  }
+}

--- a/app/(admin)/admin/quizzes/QuizQuestionsEditor.tsx
+++ b/app/(admin)/admin/quizzes/QuizQuestionsEditor.tsx
@@ -42,9 +42,9 @@ const TRUE_FALSE_OPTIONS = [
 const controlClass = `${styles.control} w-full min-w-0 max-w-full`;
 
 const btnSecondary =
-  "h-11 min-h-11 px-4 text-sm border-[#e0c4b6] bg-white text-[#1a1a1a] hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26] cursor-pointer";
+  "h-14 min-h-14 px-5 text-base md:h-11 md:min-h-11 md:px-4 md:text-sm border-[#e0c4b6] bg-white text-[#1a1a1a] hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26] cursor-pointer";
 const btnDanger =
-  "h-10 min-h-10 px-3 text-sm border-[#e0c4b6] bg-white text-[#d91f26] hover:border-[#d91f26] hover:bg-[#d91f26]/10 cursor-pointer";
+  "h-14 min-h-14 px-4 text-base md:h-10 md:min-h-10 md:px-3 md:text-sm border-[#e0c4b6] bg-white text-[#d91f26] hover:border-[#d91f26] hover:bg-[#d91f26]/10 cursor-pointer";
 
 const newQuestionId = () =>
   typeof crypto !== "undefined" && "randomUUID" in crypto

--- a/app/(admin)/admin/users/UsersManager.module.css
+++ b/app/(admin)/admin/users/UsersManager.module.css
@@ -124,6 +124,38 @@
   justify-content: flex-end;
 }
 
+.actions :global(button) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3.5rem;
+  height: auto;
+  padding: 0.75rem 1.15rem;
+  border-radius: 0.75rem;
+  font-size: 1rem;
+  font-weight: 650;
+}
+
+.actionButtonPrimary {
+  border: 0 !important;
+  background: linear-gradient(105deg, #d91f26, #f28c00) !important;
+  color: #ffffff !important;
+  box-shadow: 0 8px 18px color-mix(in oklab, #d91f26 24%, transparent);
+}
+
+.actionButtonPrimary:hover:not(:disabled) {
+  filter: brightness(1.03);
+  color: #ffffff !important;
+}
+
+@media (min-width: 768px) {
+  .actions :global(button) {
+    min-height: 2.5rem;
+    padding: 0.45rem 0.95rem;
+    font-size: 0.875rem;
+  }
+}
+
 .empty {
   padding: 1.5rem 1rem;
   text-align: center;

--- a/app/(admin)/admin/users/UsersManager.tsx
+++ b/app/(admin)/admin/users/UsersManager.tsx
@@ -199,6 +199,7 @@ export default function UsersManager({ initialUsers }: UsersManagerProps) {
                   <Button
                     type="button"
                     variant="outline"
+                    className={styles.actionButton}
                     disabled={!dirty || row.isSaving}
                     onClick={() => handleReset(row.id)}
                   >
@@ -206,6 +207,7 @@ export default function UsersManager({ initialUsers }: UsersManagerProps) {
                   </Button>
                   <Button
                     type="button"
+                    className={styles.actionButtonPrimary}
                     disabled={!dirty || row.isSaving}
                     onClick={() => void handleSave(row.id)}
                   >

--- a/components/admin/AdminShell.module.css
+++ b/components/admin/AdminShell.module.css
@@ -172,15 +172,17 @@
 @media (max-width: 860px) {
   .shell {
     flex-direction: column;
+    padding-top: env(safe-area-inset-top, 0px);
   }
 
   .sidebar {
-    position: sticky;
+    position: relative;
     inset: auto;
     width: 100%;
     height: auto;
     border-right: none;
     border-bottom: 1px solid var(--admin-outline);
+    z-index: 1;
   }
 
   .nav {
@@ -201,6 +203,16 @@
 
   .main {
     margin-left: 0;
+  }
+
+  /* Keep the page title in normal flow on mobile so it cannot cover
+     search fields / section headers while scrolling. */
+  .topBar {
+    position: relative;
+    top: auto;
+    z-index: 1;
+    background: var(--admin-surface-solid);
+    backdrop-filter: none;
   }
 
   .content {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Mobile admin quizzes/users had crushed action buttons and a sticky header that covered search/titles. This aligns quiz + users controls with the existing Events/Pre-Read mobile pattern and keeps the admin top bar in normal document flow on small screens.

## Changes
- **Quiz form**: mobile media query for full-width toolbar actions, 3.5rem button/chip/control heights, and stacked section header CTAs (including Add question)
- **Users**: larger Reset/Save touch targets with brand primary styling on Save
- **AdminShell**: remove sticky/blur top bar on mobile; add safe-area top padding so the white bar no longer covers the status bar / page content

## QA
Please manually check on a phone (or narrow viewport):
1. `/admin/users` — search fully visible under header; Reset/Save are easy to tap
2. `/admin/quizzes/new` — Cancel/Save not crushed; question-type chips and Add question have normal height
3. Scroll admin pages — header should not slide over content
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc26e-e0a8-750f-a978-78cccc5252e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc26e-e0a8-750f-a978-78cccc5252e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

