### PR TITLE
Add entire-book quiz overview generation

### DIFF
--- a/app/(admin)/admin/quizzes/QuizForm.module.css
+++ b/app/(admin)/admin/quizzes/QuizForm.module.css
@@ -479,3 +479,81 @@ textarea.control {
     grid-template-columns: minmax(0, 1fr);
   }
 }
+
+@media (max-width: 719px) {
+  .toolbar {
+    padding: 1.1rem 1rem;
+  }
+
+  .toolbarActions {
+    width: 100%;
+  }
+
+  .toolbarActions :global(button) {
+    flex: 1 1 calc(50% - 0.4rem);
+    min-height: 3.5rem;
+    height: auto;
+    padding-block: 0.85rem;
+  }
+
+  .section {
+    padding: 1.1rem 1rem;
+  }
+
+  .sectionHeaderRow {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sectionHeaderRow :global(button) {
+    width: 100%;
+    min-height: 3.5rem;
+    height: auto;
+    padding-block: 0.85rem;
+  }
+
+  .control {
+    min-height: 3.5rem;
+    font-size: 1.05rem;
+    padding: 0.85rem 1rem;
+  }
+
+  textarea.control {
+    min-height: 9rem;
+  }
+
+  .chip {
+    min-height: 3rem;
+    padding: 0.65rem 1rem;
+    font-size: 0.95rem;
+  }
+
+  .countStepperButton {
+    width: 3.5rem;
+    height: 3.5rem;
+  }
+
+  .countResetButton {
+    min-height: 3.5rem;
+    padding: 0.65rem 1rem;
+  }
+
+  .formShell :global(button:not([role="combobox"])) {
+    min-height: 3.5rem;
+  }
+
+  .formShell :global(button[role="combobox"]) {
+    min-height: 3.5rem;
+  }
+
+  .generateButton {
+    min-height: 3.5rem !important;
+    padding: 0.9rem 1.25rem !important;
+  }
+
+  .questionHeader :global(button) {
+    min-height: 3rem;
+    height: auto;
+    padding-block: 0.65rem;
+  }
+}

--- a/app/(admin)/admin/quizzes/QuizGeneratePanel.tsx
+++ b/app/(admin)/admin/quizzes/QuizGeneratePanel.tsx
@@ -247,6 +247,7 @@ export default function QuizGeneratePanel({
       difficulty: values.difficulty,
       focus: values.focus,
       questionTypes: values.questionTypes,
+      chapterCount: Math.max(1, values.endChapter - values.startChapter + 1),
     });
   }, [
     estimatedVerseCount,
@@ -254,6 +255,8 @@ export default function QuizGeneratePanel({
     values.difficulty,
     values.focus,
     values.questionTypes,
+    values.startChapter,
+    values.endChapter,
   ]);
 
   const suggestionKey = useMemo(() => {
@@ -551,6 +554,19 @@ export default function QuizGeneratePanel({
     setEndVerseCount(null);
   };
 
+  const handleEntireBook = () => {
+    if (!selectedBook) return;
+    autoEndVerseRef.current = true;
+    onChange({
+      startChapter: 1,
+      endChapter: selectedBook.chapters,
+      startVerse: 1,
+      endVerse: 1,
+    });
+    setStartVerseCount(null);
+    setEndVerseCount(null);
+  };
+
   const handleStartChapterSelect = (raw: string) => {
     const chapter = Number.parseInt(raw, 10);
     if (!Number.isFinite(chapter)) return;
@@ -616,8 +632,19 @@ export default function QuizGeneratePanel({
     !loadingStartVerses &&
     !(loadingEndVerses && !sameChapter);
 
+  const isEntireBook =
+    Boolean(selectedBook) &&
+    values.startChapter === 1 &&
+    values.startVerse === 1 &&
+    values.endChapter === (selectedBook?.chapters ?? 0) &&
+    endVerseCount != null &&
+    values.endVerse === endVerseCount;
+
   const verseHelper = (() => {
     if (!selectedBook) return "Pick a book to unlock chapter and verse bounds.";
+    if (isEntireBook) {
+      return `Entire ${selectedBook.name} selected (${selectedBook.chapters} chapters). Generate creates a book overview quiz (up to ${QUIZ_QUESTION_COUNT_BOUNDS.max} questions).`;
+    }
     if (loadingStartVerses || (loadingEndVerses && !sameChapter)) {
       return "Loading verse bounds…";
     }
@@ -636,8 +663,8 @@ export default function QuizGeneratePanel({
         <p className={styles.sectionEyebrow}>Passage</p>
         <h3 className={styles.sectionTitle}>Generate from scripture</h3>
         <p className={styles.sectionMeta}>
-          Choose a translation and range, tune the knobs, then generate a draft.
-          Nothing is saved until you hit Save.
+          Choose a translation and range — or an entire book for an overview
+          quiz — then generate a draft. Nothing is saved until you hit Save.
         </p>
       </div>
 
@@ -684,6 +711,53 @@ export default function QuizGeneratePanel({
             triggerClassName={controlClass}
             aria-label="Bible book"
           />
+        </div>
+
+        <div className={`${styles.field} ${styles.fieldWide}`}>
+          <span className={styles.label}>Range preset</span>
+          <div className={styles.chipGroup} role="group" aria-label="Range preset">
+            <button
+              type="button"
+              className={
+                selectedBook && !isEntireBook
+                  ? `${styles.chip} ${styles.chipActive}`
+                  : styles.chip
+              }
+              disabled={busy || !selectedBook}
+              aria-pressed={Boolean(selectedBook && !isEntireBook)}
+              onClick={() => {
+                if (!selectedBook || !isEntireBook) return;
+                autoEndVerseRef.current = true;
+                onChange({
+                  startChapter: 1,
+                  endChapter: 1,
+                  startVerse: 1,
+                  endVerse: 1,
+                });
+                setStartVerseCount(null);
+                setEndVerseCount(null);
+              }}
+            >
+              Custom range
+            </button>
+            <button
+              type="button"
+              className={
+                isEntireBook ? `${styles.chip} ${styles.chipActive}` : styles.chip
+              }
+              disabled={busy || !selectedBook}
+              aria-pressed={isEntireBook}
+              onClick={handleEntireBook}
+            >
+              Entire book
+              {selectedBook ? ` (${selectedBook.chapters} ch.)` : ""}
+            </button>
+          </div>
+          <p className={styles.helper}>
+            {isEntireBook
+              ? "Builds one overview quiz across the whole book — major people, events, and themes — not a verse-by-verse exam."
+              : "Pick chapters and verses below, or switch to Entire book for a Genesis-style overview in one step."}
+          </p>
         </div>
 
         <div className={styles.field}>
@@ -929,10 +1003,9 @@ export default function QuizGeneratePanel({
                 ) : null}
               </div>
               <p className={styles.helper}>
-                Based on about {estimatedVerseCount} verse
-                {estimatedVerseCount === 1 ? "" : "s"} in this range,{" "}
-                {values.difficulty} difficulty, and {values.focus} focus. Nudge
-                up or down if you want a shorter or deeper quiz.
+                {isEntireBook
+                  ? `Book overview across about ${estimatedVerseCount} verses in ${selectedBook?.name ?? "this book"}, ${values.difficulty} difficulty, and ${values.focus} focus. Suggests a fuller quiz near the ${QUIZ_QUESTION_COUNT_BOUNDS.max}-question cap.`
+                  : `Based on about ${estimatedVerseCount} verse${estimatedVerseCount === 1 ? "" : "s"} in this range, ${values.difficulty} difficulty, and ${values.focus} focus. Nudge up or down if you want a shorter or deeper quiz.`}
               </p>
             </>
           )}
@@ -961,7 +1034,11 @@ export default function QuizGeneratePanel({
           disabled={busy || !rangeReady}
           onClick={onGenerate}
         >
-          {generating ? "Generating…" : "Generate draft"}
+          {generating
+            ? "Generating…"
+            : isEntireBook
+              ? "Generate book overview"
+              : "Generate draft"}
         </Button>
       </div>
     </section>

--- a/app/(admin)/admin/quizzes/QuizQuestionsEditor.tsx
+++ b/app/(admin)/admin/quizzes/QuizQuestionsEditor.tsx
@@ -42,9 +42,9 @@ const TRUE_FALSE_OPTIONS = [
 const controlClass = `${styles.control} w-full min-w-0 max-w-full`;
 
 const btnSecondary =
-  "h-11 min-h-11 px-4 text-sm border-[#e0c4b6] bg-white text-[#1a1a1a] hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26] cursor-pointer";
+  "h-14 min-h-14 px-5 text-base md:h-11 md:min-h-11 md:px-4 md:text-sm border-[#e0c4b6] bg-white text-[#1a1a1a] hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26] cursor-pointer";
 const btnDanger =
-  "h-10 min-h-10 px-3 text-sm border-[#e0c4b6] bg-white text-[#d91f26] hover:border-[#d91f26] hover:bg-[#d91f26]/10 cursor-pointer";
+  "h-14 min-h-14 px-4 text-base md:h-10 md:min-h-10 md:px-3 md:text-sm border-[#e0c4b6] bg-white text-[#d91f26] hover:border-[#d91f26] hover:bg-[#d91f26]/10 cursor-pointer";
 
 const newQuestionId = () =>
   typeof crypto !== "undefined" && "randomUUID" in crypto

--- a/app/(admin)/admin/users/UsersManager.module.css
+++ b/app/(admin)/admin/users/UsersManager.module.css
@@ -124,6 +124,38 @@
   justify-content: flex-end;
 }
 
+.actions :global(button) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3.5rem;
+  height: auto;
+  padding: 0.75rem 1.15rem;
+  border-radius: 0.75rem;
+  font-size: 1rem;
+  font-weight: 650;
+}
+
+.actionButtonPrimary {
+  border: 0 !important;
+  background: linear-gradient(105deg, #d91f26, #f28c00) !important;
+  color: #ffffff !important;
+  box-shadow: 0 8px 18px color-mix(in oklab, #d91f26 24%, transparent);
+}
+
+.actionButtonPrimary:hover:not(:disabled) {
+  filter: brightness(1.03);
+  color: #ffffff !important;
+}
+
+@media (min-width: 768px) {
+  .actions :global(button) {
+    min-height: 2.5rem;
+    padding: 0.45rem 0.95rem;
+    font-size: 0.875rem;
+  }
+}
+
 .empty {
   padding: 1.5rem 1rem;
   text-align: center;

--- a/app/(admin)/admin/users/UsersManager.tsx
+++ b/app/(admin)/admin/users/UsersManager.tsx
@@ -199,6 +199,7 @@ export default function UsersManager({ initialUsers }: UsersManagerProps) {
                   <Button
                     type="button"
                     variant="outline"
+                    className={styles.actionButton}
                     disabled={!dirty || row.isSaving}
                     onClick={() => handleReset(row.id)}
                   >
@@ -206,6 +207,7 @@ export default function UsersManager({ initialUsers }: UsersManagerProps) {
                   </Button>
                   <Button
                     type="button"
+                    className={styles.actionButtonPrimary}
                     disabled={!dirty || row.isSaving}
                     onClick={() => void handleSave(row.id)}
                   >

--- a/components/admin/AdminShell.module.css
+++ b/components/admin/AdminShell.module.css
@@ -172,15 +172,17 @@
 @media (max-width: 860px) {
   .shell {
     flex-direction: column;
+    padding-top: env(safe-area-inset-top, 0px);
   }
 
   .sidebar {
-    position: sticky;
+    position: relative;
     inset: auto;
     width: 100%;
     height: auto;
     border-right: none;
     border-bottom: 1px solid var(--admin-outline);
+    z-index: 1;
   }
 
   .nav {
@@ -201,6 +203,16 @@
 
   .main {
     margin-left: 0;
+  }
+
+  /* Keep the page title in normal flow on mobile so it cannot cover
+     search fields / section headers while scrolling. */
+  .topBar {
+    position: relative;
+    top: auto;
+    z-index: 1;
+    background: var(--admin-surface-solid);
+    backdrop-filter: none;
   }
 
   .content {

--- a/lib/ai/quiz-generate.ts
+++ b/lib/ai/quiz-generate.ts
@@ -13,6 +13,10 @@ import type {
 } from "@/types/quizzes";
 
 import { getOpenAIClient, QUIZ_MODEL } from "@/lib/ai/openai";
+import {
+  buildPassagePromptPayload,
+  type PassagePromptPayload,
+} from "@/lib/quizzes/passage-prompt";
 import { suggestQuizQuestionCount } from "@/lib/quizzes/suggest-count";
 
 export {
@@ -257,13 +261,6 @@ export function normalizeGenerateRequest(
   };
 }
 
-const formatPassageForPrompt = (passage: BiblePassageResponse) =>
-  passage.verses
-    .map(({ chapter, verse, text: verseText }) =>
-      `${chapter}:${verse} ${verseText.trim()}`,
-    )
-    .join("\n");
-
 const formatRangeLabel = (
   book: string,
   start: QuizVerseRef,
@@ -408,8 +405,8 @@ type ModelQuizPayload = {
   questions?: unknown;
 };
 
-const buildSystemPrompt = () =>
-  [
+const buildSystemPrompt = (overview: boolean) => {
+  const base = [
     "You generate Bible study quizzes strictly from the provided passage text.",
     "Do not invent details that are not supported by the passage.",
     "Every question must include a citation in book chapter:verse form when possible.",
@@ -422,20 +419,37 @@ const buildSystemPrompt = () =>
     "otherwise invent a short, specific title by reasoning over the passage's main theme,",
     "people, events, or teaching — not a bare reference like \"Genesis 1:1-31\" or \"Quiz: John 3\".",
     `Keep question count between ${PLATFORM.minQuestions} and ${PLATFORM.maxQuestions}.`,
-  ].join(" ");
+  ];
+
+  if (overview) {
+    base.push(
+      "This is a BOOK or multi-chapter OVERVIEW quiz.",
+      "The passage text is a representative sample across chapters, not the complete book.",
+      "Write questions that cover major people, events, themes, and the arc of the whole range.",
+      "Spread citations across different chapters when possible.",
+      "Prefer thematic and application questions over obscure trivia that requires verses not shown.",
+      "Title the quiz as a book overview when the range covers most or all of a book (e.g. \"Genesis Overview\").",
+    );
+  }
+
+  return base.join(" ");
+};
 
 const buildUserPrompt = (
   request: QuizGenerateRequest,
-  passage: BiblePassageResponse,
   seed: number,
   targetCount: number,
+  promptPayload: PassagePromptPayload,
 ) => {
   const rangeLabel = formatRangeLabel(request.book, request.start, request.end);
   const preferredTitle = request.title?.trim();
 
   return [
     `Passage: ${rangeLabel} (${request.translation})`,
-    `Verse count: ${passage.verses.length}`,
+    `Verse count: ${promptPayload.totalVerseCount}`,
+    promptPayload.overview
+      ? `Mode: book/section overview (${promptPayload.sampledVerseCount} sample verses across ${promptPayload.chapterCount} chapters)`
+      : "Mode: full passage",
     `Difficulty: ${request.difficulty}`,
     `Focus: ${request.focus}`,
     `Allowed question types: ${request.questionTypes.join(", ")}`,
@@ -445,14 +459,15 @@ const buildUserPrompt = (
       ? `Preferred title (use this): ${preferredTitle}`
       : [
           "Title: none provided.",
-          "Read the passage, identify its central theme or moment,",
-          "and invent a concise quiz title (about 3–8 words) that reflects that content.",
-          "Examples of good style: \"Light in the Darkness\", \"The Good Samaritan\", \"Faith Without Works\".",
+          promptPayload.overview
+            ? "Invent a concise overview title that names the book or section (about 3–8 words)."
+            : "Read the passage, identify its central theme or moment, and invent a concise quiz title (about 3–8 words) that reflects that content.",
+          "Examples of good style: \"Light in the Darkness\", \"The Good Samaritan\", \"Genesis Overview\".",
           "Do not use only the book/chapter/verse reference as the title.",
         ].join(" "),
     "",
-    "Passage text:",
-    formatPassageForPrompt(passage),
+    promptPayload.overview ? "Passage sample (overview):" : "Passage text:",
+    promptPayload.text,
     "",
     "Respond with JSON:",
     '{ "title": string, "suggestedQuestionCount": number, "questions": [',
@@ -495,8 +510,11 @@ export async function generateQuizFromPassage(
     difficulty: request.difficulty,
     focus: request.focus,
     questionTypes: request.questionTypes,
+    chapterCount:
+      request.end.chapter - request.start.chapter + 1,
   });
   const targetCount = request.questionCount ?? heuristicCount;
+  const promptPayload = buildPassagePromptPayload(passage);
 
   const client = getOpenAIClient();
   let completion;
@@ -507,10 +525,15 @@ export async function generateQuizFromPassage(
       seed,
       response_format: { type: "json_object" },
       messages: [
-        { role: "system", content: buildSystemPrompt() },
+        { role: "system", content: buildSystemPrompt(promptPayload.overview) },
         {
           role: "user",
-          content: buildUserPrompt(request, passage, seed, targetCount),
+          content: buildUserPrompt(
+            request,
+            seed,
+            targetCount,
+            promptPayload,
+          ),
         },
       ],
     });

--- a/lib/quizzes/passage-prompt.ts
+++ b/lib/quizzes/passage-prompt.ts
@@ -1,0 +1,134 @@
+import type {
+  BiblePassageResponse,
+  BiblePassageVerse,
+} from "@/types/bible";
+
+/** Full text is fine for short/medium passages; larger spans use overview sampling. */
+export const FULL_PROMPT_VERSE_LIMIT = 80;
+
+/** Soft cap on verses sent to the model for book/section overviews. */
+export const OVERVIEW_SAMPLE_VERSE_LIMIT = 120;
+
+/** Prefer a few verses from each chapter so coverage spans the book. */
+export const OVERVIEW_VERSES_PER_CHAPTER = 4;
+
+export type PassagePromptPayload = {
+  text: string;
+  overview: boolean;
+  sampledVerseCount: number;
+  totalVerseCount: number;
+  chapterCount: number;
+};
+
+const groupVersesByChapter = (verses: BiblePassageVerse[]) => {
+  const byChapter = new Map<number, BiblePassageVerse[]>();
+  for (const verse of verses) {
+    const list = byChapter.get(verse.chapter) ?? [];
+    list.push(verse);
+    byChapter.set(verse.chapter, list);
+  }
+  return byChapter;
+};
+
+/**
+ * Pick evenly spaced verses from a chapter so overview quizzes cover
+ * beginning, middle, and end rather than only the opening lines.
+ */
+export function sampleChapterVerses(
+  chapterVerses: BiblePassageVerse[],
+  limit = OVERVIEW_VERSES_PER_CHAPTER,
+): BiblePassageVerse[] {
+  if (chapterVerses.length <= limit) {
+    return chapterVerses;
+  }
+
+  if (limit <= 1) {
+    return [chapterVerses[0]];
+  }
+
+  const sampled: BiblePassageVerse[] = [];
+  const lastIndex = chapterVerses.length - 1;
+  for (let i = 0; i < limit; i += 1) {
+    const index =
+      i === limit - 1
+        ? lastIndex
+        : Math.round((i * lastIndex) / (limit - 1));
+    const verse = chapterVerses[index];
+    if (!sampled.some((item) => item.verse === verse.verse)) {
+      sampled.push(verse);
+    }
+  }
+  return sampled;
+}
+
+export function isOverviewPassage(passage: BiblePassageResponse): boolean {
+  const chapterSpan =
+    passage.range.end.chapter - passage.range.start.chapter + 1;
+  return (
+    passage.verses.length > FULL_PROMPT_VERSE_LIMIT || chapterSpan >= 4
+  );
+}
+
+const formatVerseLine = (verse: BiblePassageVerse) =>
+  `${verse.chapter}:${verse.verse} ${verse.text.trim()}`;
+
+/**
+ * Build the scripture block for the quiz generation prompt.
+ * Short ranges get the full text; book-scale ranges get a stratified sample
+ * so Genesis-sized requests stay within model context.
+ */
+export function buildPassagePromptPayload(
+  passage: BiblePassageResponse,
+): PassagePromptPayload {
+  const totalVerseCount = passage.verses.length;
+  const byChapter = groupVersesByChapter(passage.verses);
+  const chapterCount = byChapter.size;
+
+  if (!isOverviewPassage(passage)) {
+    return {
+      text: passage.verses.map(formatVerseLine).join("\n"),
+      overview: false,
+      sampledVerseCount: totalVerseCount,
+      totalVerseCount,
+      chapterCount,
+    };
+  }
+
+  const perChapter = Math.max(
+    1,
+    Math.min(
+      OVERVIEW_VERSES_PER_CHAPTER,
+      Math.floor(OVERVIEW_SAMPLE_VERSE_LIMIT / Math.max(chapterCount, 1)),
+    ),
+  );
+
+  const sampled: BiblePassageVerse[] = [];
+  const chapterNumbers = [...byChapter.keys()].sort((a, b) => a - b);
+  for (const chapter of chapterNumbers) {
+    sampled.push(
+      ...sampleChapterVerses(byChapter.get(chapter) ?? [], perChapter),
+    );
+  }
+
+  const capped = sampled.slice(0, OVERVIEW_SAMPLE_VERSE_LIMIT);
+  const lines: string[] = [
+    `[Overview sample: ${capped.length} of ${totalVerseCount} verses across ${chapterCount} chapters. Questions should cover the arc of the whole range.]`,
+  ];
+
+  let currentChapter: number | null = null;
+  for (const verse of capped) {
+    if (verse.chapter !== currentChapter) {
+      currentChapter = verse.chapter;
+      lines.push(`--- Chapter ${currentChapter} ---`);
+    }
+    lines.push(formatVerseLine(verse));
+  }
+
+  return {
+    text: lines.join("\n"),
+    overview: true,
+    sampledVerseCount: capped.length,
+    totalVerseCount,
+    chapterCount,
+  };
+}

--- a/lib/quizzes/suggest-count.ts
+++ b/lib/quizzes/suggest-count.ts
@@ -35,9 +35,21 @@ export function suggestQuizQuestionCount(options: {
   difficulty?: QuizDifficulty;
   focus?: QuizFocus;
   questionTypes?: QuizQuestionType[];
+  /** When set, multi-chapter / book spans lean toward fuller overview quizzes. */
+  chapterCount?: number;
 }): number {
   const verseCount = Math.max(0, Math.floor(options.verseCount));
+  const chapterCount = Math.max(1, Math.floor(options.chapterCount ?? 1));
   let count = baseCountFromVerseCount(verseCount);
+
+  // Book/section overviews should sit near the top of the allowed band.
+  if (chapterCount >= 20 || verseCount >= 800) {
+    count = Math.max(count, 18);
+  } else if (chapterCount >= 8 || verseCount >= 200) {
+    count = Math.max(count, 16);
+  } else if (chapterCount >= 4 || verseCount >= 80) {
+    count = Math.max(count, 14);
+  }
 
   if (options.difficulty === "easy") count -= 1;
   if (options.difficulty === "hard") count += 2;
@@ -50,7 +62,9 @@ export function suggestQuizQuestionCount(options: {
   if (typeCount >= 3) count += 1;
 
   // Very short passages cannot support a large quiz well.
-  if (verseCount > 0) {
+  // Skip this clamp for multi-chapter overviews where verseCount is large
+  // but questions intentionally sample themes rather than every verse.
+  if (verseCount > 0 && chapterCount < 4 && verseCount < 80) {
     count = Math.min(count, Math.max(MIN_QUESTIONS, verseCount + 2));
   }
 

--- a/tests/passagePrompt.test.mjs
+++ b/tests/passagePrompt.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { loadTsModule } from "./utils/load-ts-module.mjs";
+
+const loadPassagePrompt = async () =>
+  loadTsModule("lib/quizzes/passage-prompt.ts");
+
+const loadSuggestCount = async () =>
+  loadTsModule("lib/quizzes/suggest-count.ts");
+
+const makePassage = ({
+  chapters,
+  versesPerChapter = 10,
+}) => {
+  const verses = [];
+  for (let chapter = 1; chapter <= chapters; chapter += 1) {
+    for (let verse = 1; verse <= versesPerChapter; verse += 1) {
+      verses.push({
+        chapter,
+        verse,
+        text: `Chapter ${chapter} verse ${verse} text.`,
+      });
+    }
+  }
+
+  return {
+    translation: { code: "WEB", name: "World English Bible" },
+    book: {
+      id: "genesis",
+      name: "Genesis",
+      abbreviation: "Gen",
+      chapters,
+    },
+    range: {
+      start: { chapter: 1, verse: 1 },
+      end: { chapter: chapters, verse: versesPerChapter },
+    },
+    verses,
+  };
+};
+
+describe("passage prompt overview sampling", () => {
+  it("keeps short passages as full text", async () => {
+    const { buildPassagePromptPayload, isOverviewPassage } =
+      await loadPassagePrompt();
+    const passage = makePassage({ chapters: 1, versesPerChapter: 20 });
+
+    assert.equal(isOverviewPassage(passage), false);
+    const payload = buildPassagePromptPayload(passage);
+    assert.equal(payload.overview, false);
+    assert.equal(payload.sampledVerseCount, 20);
+    assert.match(payload.text, /^1:1 /);
+    assert.doesNotMatch(payload.text, /Overview sample/);
+  });
+
+  it("samples evenly across many chapters for book overviews", async () => {
+    const {
+      buildPassagePromptPayload,
+      isOverviewPassage,
+      OVERVIEW_SAMPLE_VERSE_LIMIT,
+    } = await loadPassagePrompt();
+    const passage = makePassage({ chapters: 50, versesPerChapter: 30 });
+
+    assert.equal(isOverviewPassage(passage), true);
+    const payload = buildPassagePromptPayload(passage);
+    assert.equal(payload.overview, true);
+    assert.equal(payload.totalVerseCount, 1500);
+    assert.ok(payload.sampledVerseCount <= OVERVIEW_SAMPLE_VERSE_LIMIT);
+    assert.ok(payload.sampledVerseCount < payload.totalVerseCount);
+    assert.match(payload.text, /Overview sample/);
+    assert.match(payload.text, /--- Chapter 1 ---/);
+    assert.match(payload.text, /--- Chapter 50 ---/);
+  });
+
+  it("samples beginning and end within a chapter", async () => {
+    const { sampleChapterVerses } = await loadPassagePrompt();
+    const chapterVerses = Array.from({ length: 10 }, (_v, i) => ({
+      chapter: 3,
+      verse: i + 1,
+      text: `v${i + 1}`,
+    }));
+
+    const sampled = sampleChapterVerses(chapterVerses, 4);
+    assert.equal(sampled[0].verse, 1);
+    assert.equal(sampled[sampled.length - 1].verse, 10);
+    assert.equal(sampled.length, 4);
+  });
+});
+
+describe("suggestQuizQuestionCount for book spans", () => {
+  it("suggests a fuller quiz for entire-book sized ranges", async () => {
+    const { suggestQuizQuestionCount, QUIZ_QUESTION_COUNT_BOUNDS } =
+      await loadSuggestCount();
+
+    const bookCount = suggestQuizQuestionCount({
+      verseCount: 1500,
+      chapterCount: 50,
+      difficulty: "medium",
+      focus: "mixed",
+      questionTypes: ["multiple_choice", "short_answer"],
+    });
+
+    assert.ok(bookCount >= 16);
+    assert.ok(bookCount <= QUIZ_QUESTION_COUNT_BOUNDS.max);
+  });
+
+  it("still keeps short passages small", async () => {
+    const { suggestQuizQuestionCount } = await loadSuggestCount();
+    const shortCount = suggestQuizQuestionCount({
+      verseCount: 4,
+      chapterCount: 1,
+      difficulty: "medium",
+      focus: "factual",
+      questionTypes: ["multiple_choice"],
+    });
+    assert.equal(shortCount, 3);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Admins can generate a full **book overview quiz** end to end (e.g. Genesis) without picking chapter/verse ranges by hand.

**Already merged to `staging` for QA.**

## How it works
1. Pick translation + book on `/admin/quizzes/new`
2. Tap **Entire book**
3. Tune knobs → **Generate book overview**
4. Review questions → Save

Large ranges are sampled across chapters for the model so Genesis-sized requests stay in context. Result is an overview quiz (major people/events/themes, up to 20 questions), not a verse-by-verse exam of the whole book.

## Staging preview
https://sword-git-staging-grimmzs-projects.vercel.app  
Deployment: https://sword-muy7oiexf-grimmzs-projects.vercel.app

## QA
`/admin/quizzes/new` → Genesis → Entire book → Generate book overview → confirm draft questions cite multiple chapters.

Note: this branch is tip-of-staging, so it also includes the prior mobile slim-button / header overlap fix already on staging.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc26e-e0a8-750f-a978-78cccc5252e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc26e-e0a8-750f-a978-78cccc5252e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

