### PR TITLE
Add chapter-pack generation for entire books

### DIFF
--- a/app/(admin)/admin/quizzes/QuizForm.module.css
+++ b/app/(admin)/admin/quizzes/QuizForm.module.css
@@ -306,8 +306,88 @@ textarea.control {
   cursor: not-allowed;
 }
 
+.packButton {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  box-sizing: border-box;
+  min-height: 3.5rem !important;
+  height: auto !important;
+  width: 100%;
+  min-width: 0;
+  padding: 0.9rem 1.25rem !important;
+  border: 1.5px solid #e0c4b6 !important;
+  border-radius: 0.75rem !important;
+  background: #ffffff !important;
+  color: #d91f26 !important;
+  font-size: 1rem !important;
+  font-weight: 700 !important;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.packButton:hover:not(:disabled) {
+  border-color: #d91f26 !important;
+  background: color-mix(in oklab, #d91f26 8%, #ffffff) !important;
+}
+
+.packButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.packCancelButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 0.75rem;
+  border: 1.5px solid #e0c4b6;
+  background: #fff8f4;
+  color: #1a1a1a;
+  font-size: 0.9rem;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.packCancelButton:hover {
+  border-color: #d91f26;
+  color: #d91f26;
+}
+
+.packProgress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  width: 100%;
+}
+
+.packProgressTrack {
+  width: 100%;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: #ffe8dc;
+  overflow: hidden;
+}
+
+.packProgressBar {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #d91f26, #f28c00);
+  transition: width 200ms ease;
+}
+
 @media (min-width: 720px) {
   .generateButton {
+    width: auto;
+    min-height: 2.75rem !important;
+    padding: 0.75rem 1.15rem !important;
+    font-size: 0.9rem !important;
+  }
+
+  .packButton {
     width: auto;
     min-height: 2.75rem !important;
     padding: 0.75rem 1.15rem !important;

--- a/app/(admin)/admin/quizzes/QuizForm.module.css
+++ b/app/(admin)/admin/quizzes/QuizForm.module.css
@@ -479,3 +479,81 @@ textarea.control {
     grid-template-columns: minmax(0, 1fr);
   }
 }
+
+@media (max-width: 719px) {
+  .toolbar {
+    padding: 1.1rem 1rem;
+  }
+
+  .toolbarActions {
+    width: 100%;
+  }
+
+  .toolbarActions :global(button) {
+    flex: 1 1 calc(50% - 0.4rem);
+    min-height: 3.5rem;
+    height: auto;
+    padding-block: 0.85rem;
+  }
+
+  .section {
+    padding: 1.1rem 1rem;
+  }
+
+  .sectionHeaderRow {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sectionHeaderRow :global(button) {
+    width: 100%;
+    min-height: 3.5rem;
+    height: auto;
+    padding-block: 0.85rem;
+  }
+
+  .control {
+    min-height: 3.5rem;
+    font-size: 1.05rem;
+    padding: 0.85rem 1rem;
+  }
+
+  textarea.control {
+    min-height: 9rem;
+  }
+
+  .chip {
+    min-height: 3rem;
+    padding: 0.65rem 1rem;
+    font-size: 0.95rem;
+  }
+
+  .countStepperButton {
+    width: 3.5rem;
+    height: 3.5rem;
+  }
+
+  .countResetButton {
+    min-height: 3.5rem;
+    padding: 0.65rem 1rem;
+  }
+
+  .formShell :global(button:not([role="combobox"])) {
+    min-height: 3.5rem;
+  }
+
+  .formShell :global(button[role="combobox"]) {
+    min-height: 3.5rem;
+  }
+
+  .generateButton {
+    min-height: 3.5rem !important;
+    padding: 0.9rem 1.25rem !important;
+  }
+
+  .questionHeader :global(button) {
+    min-height: 3rem;
+    height: auto;
+    padding-block: 0.65rem;
+  }
+}

--- a/app/(admin)/admin/quizzes/QuizForm.tsx
+++ b/app/(admin)/admin/quizzes/QuizForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
@@ -10,10 +10,16 @@ import {
   createAdminQuiz,
   deleteAdminQuiz,
   generateAdminQuiz,
+  listAdminQuizzes,
   updateAdminQuiz,
 } from "@/lib/api/admin-quizzes";
 import { getBooksForTranslation } from "@/lib/api/bible";
 import { ApiError } from "@/lib/api/fetch";
+import {
+  hasExistingChapterQuiz,
+  planChapterPack,
+  type ChapterPackProgress,
+} from "@/lib/quizzes/chapter-pack";
 import { quizDraftToInput } from "@/lib/quizzes/draft-to-input";
 import type { BibleBookSummary, BibleTranslationSummary } from "@/types/bible";
 import type {
@@ -137,6 +143,10 @@ export default function QuizForm({
   const [generating, setGenerating] = useState(false);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [packProgress, setPackProgress] = useState<ChapterPackProgress | null>(
+    null,
+  );
+  const packCancelRef = useRef(false);
 
   useEffect(() => {
     const code = panel.translation;
@@ -334,6 +344,196 @@ export default function QuizForm({
     }
   };
 
+  const handleCancelChapterPack = () => {
+    packCancelRef.current = true;
+  };
+
+  const handleGenerateChapterPack = async () => {
+    if (mode !== "create") {
+      toast.error("Chapter packs can only be created from New quiz");
+      return;
+    }
+    if (!panel.book) {
+      toast.error("Select a book before generating a chapter pack");
+      return;
+    }
+
+    const selectedBook = books.find((book) => book.name === panel.book);
+    if (!selectedBook || selectedBook.chapters < 1) {
+      toast.error("Could not resolve chapter count for this book");
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Create up to ${selectedBook.chapters} draft quizzes for ${selectedBook.name} (one per chapter)?\n\nChapters that already have a quiz for ${panel.translation} will be skipped. Keep this tab open until it finishes.`,
+    );
+    if (!confirmed) return;
+
+    const plan = planChapterPack({
+      book: selectedBook.name,
+      translation: panel.translation,
+      chapterCount: selectedBook.chapters,
+    });
+
+    packCancelRef.current = false;
+    let created = 0;
+    let skipped = 0;
+    let failed = 0;
+    let existing: Quiz[] = [];
+
+    try {
+      const listed = await listAdminQuizzes();
+      existing = listed.quizzes;
+    } catch {
+      // Non-fatal — pack still runs, just without skip detection.
+      existing = [];
+    }
+
+    const clampedAttempts = Math.min(
+      MAX_MAX_ATTEMPTS,
+      Math.max(MIN_MAX_ATTEMPTS, Math.round(maxAttempts) || DEFAULT_MAX_ATTEMPTS),
+    );
+
+    setPackProgress({
+      status: "running",
+      total: plan.jobs.length,
+      index: 0,
+      chapter: 0,
+      created,
+      skipped,
+      failed,
+      message: `Starting ${selectedBook.name} chapter pack…`,
+    });
+
+    for (let i = 0; i < plan.jobs.length; i += 1) {
+      if (packCancelRef.current) {
+        setPackProgress({
+          status: "cancelled",
+          total: plan.jobs.length,
+          index: i,
+          chapter: plan.jobs[i]?.chapter ?? 0,
+          created,
+          skipped,
+          failed,
+          message: `Cancelled after ${created} created, ${skipped} skipped, ${failed} failed.`,
+        });
+        toast.message("Chapter pack cancelled");
+        return;
+      }
+
+      const job = plan.jobs[i];
+      setPackProgress({
+        status: "running",
+        total: plan.jobs.length,
+        index: i,
+        chapter: job.chapter,
+        created,
+        skipped,
+        failed,
+        message: `Generating ${selectedBook.name} ${job.chapter} (${i + 1}/${plan.jobs.length})…`,
+      });
+
+      if (
+        hasExistingChapterQuiz(existing, {
+          book: selectedBook.name,
+          translation: panel.translation,
+          chapter: job.chapter,
+        })
+      ) {
+        skipped += 1;
+        continue;
+      }
+
+      try {
+        // Load chapter length so the range covers the full chapter.
+        const chapterResponse = await fetch(
+          `/api/bible/${encodeURIComponent(selectedBook.name)}/${job.chapter}?translation=${encodeURIComponent(panel.translation)}`,
+          { cache: "no-store" },
+        );
+        if (!chapterResponse.ok) {
+          throw new Error(`Unable to load ${selectedBook.name} ${job.chapter}`);
+        }
+        const chapterPayload = (await chapterResponse.json()) as {
+          verses?: unknown[];
+        };
+        const endVerse = Array.isArray(chapterPayload.verses)
+          ? Math.max(1, chapterPayload.verses.length)
+          : 1;
+
+        const request: QuizGenerateRequest = {
+          translation: panel.translation,
+          book: selectedBook.name,
+          start: { chapter: job.chapter, verse: 1 },
+          end: { chapter: job.chapter, verse: endVerse },
+          difficulty: panel.difficulty,
+          questionTypes: panel.questionTypes,
+          focus: panel.focus,
+          temperature: panel.temperature,
+          title: job.titleHint,
+          ...(panel.seed.trim()
+            ? { seed: Number(panel.seed) + job.chapter }
+            : {}),
+        };
+
+        const { draft } = await generateAdminQuiz(request);
+        const mapped = quizDraftToInput(draft, "draft", clampedAttempts);
+        // Prefer the chapter label if the model returns something vague.
+        if (!mapped.title.trim()) {
+          mapped.title = job.titleHint;
+        }
+        const { quiz } = await createAdminQuiz(mapped);
+        existing = [quiz, ...existing];
+        created += 1;
+      } catch (error: unknown) {
+        failed += 1;
+        const message =
+          error instanceof ApiError
+            ? error.message
+            : error instanceof Error
+              ? error.message
+              : "Chapter generate failed";
+        setPackProgress({
+          status: "running",
+          total: plan.jobs.length,
+          index: i + 1,
+          chapter: job.chapter,
+          created,
+          skipped,
+          failed,
+          message: `Failed ${selectedBook.name} ${job.chapter}: ${message}`,
+        });
+        // Continue remaining chapters rather than aborting the whole pack.
+      }
+    }
+
+    setPackProgress({
+      status: "done",
+      total: plan.jobs.length,
+      index: plan.jobs.length,
+      chapter: plan.jobs[plan.jobs.length - 1]?.chapter ?? 0,
+      created,
+      skipped,
+      failed,
+      message: `Done — ${created} created, ${skipped} skipped, ${failed} failed.`,
+    });
+
+    if (created > 0) {
+      toast.success(
+        `Chapter pack ready: ${created} draft${created === 1 ? "" : "s"} for ${selectedBook.name}`,
+      );
+      router.push("/admin/quizzes");
+      router.refresh();
+      return;
+    }
+
+    if (failed > 0) {
+      toast.error("Chapter pack finished with errors and no new drafts");
+      return;
+    }
+
+    toast.message("Nothing new to create — all chapters already had quizzes");
+  };
+
   const handleSave = async () => {
     const input = buildInput();
     if (!input) return;
@@ -387,7 +587,11 @@ export default function QuizForm({
     }
   };
 
-  const busy = generating || saving || deleting;
+  const busy =
+    generating ||
+    saving ||
+    deleting ||
+    packProgress?.status === "running";
 
   return (
     <div className={styles.formShell}>
@@ -514,9 +718,13 @@ export default function QuizForm({
           books={books}
           booksLoading={booksLoading}
           generating={generating}
-          disabled={busy && !generating}
+          disabled={busy && !generating && packProgress?.status !== "running"}
+          allowChapterPack={mode === "create"}
+          packProgress={packProgress}
           onChange={patchPanel}
           onGenerate={handleGenerate}
+          onGenerateChapterPack={handleGenerateChapterPack}
+          onCancelChapterPack={handleCancelChapterPack}
         />
 
         <QuizQuestionsEditor

--- a/app/(admin)/admin/quizzes/QuizGeneratePanel.tsx
+++ b/app/(admin)/admin/quizzes/QuizGeneratePanel.tsx
@@ -24,6 +24,7 @@ import type {
   QuizFocus,
   QuizQuestionType,
 } from "@/types/quizzes";
+import type { ChapterPackProgress } from "@/lib/quizzes/chapter-pack";
 
 import styles from "./QuizForm.module.css";
 
@@ -146,8 +147,13 @@ type QuizGeneratePanelProps = {
   booksLoading: boolean;
   generating: boolean;
   disabled?: boolean;
+  /** Create-mode only: allow generating one draft quiz per chapter. */
+  allowChapterPack?: boolean;
+  packProgress?: ChapterPackProgress | null;
   onChange: (patch: Partial<QuizGeneratePanelValues>) => void;
   onGenerate: () => void;
+  onGenerateChapterPack?: () => void;
+  onCancelChapterPack?: () => void;
 };
 
 const clampInt = (value: number, min: number, max: number) =>
@@ -196,8 +202,12 @@ export default function QuizGeneratePanel({
   booksLoading,
   generating,
   disabled = false,
+  allowChapterPack = false,
+  packProgress = null,
   onChange,
   onGenerate,
+  onGenerateChapterPack,
+  onCancelChapterPack,
 }: QuizGeneratePanelProps) {
   const valuesRef = useRef(values);
   valuesRef.current = values;
@@ -304,7 +314,8 @@ export default function QuizGeneratePanel({
   }, [selectedBook]);
 
   const sameChapter = values.startChapter === values.endChapter;
-  const busy = disabled || generating;
+  const packing = packProgress?.status === "running";
+  const busy = disabled || generating || packing;
   const controlClass = `${styles.control} w-full min-w-0 max-w-full`;
 
   const chapterComboboxOptions = useMemo(
@@ -1040,7 +1051,54 @@ export default function QuizGeneratePanel({
               ? "Generate book overview"
               : "Generate draft"}
         </Button>
+        {allowChapterPack && onGenerateChapterPack ? (
+          <Button
+            type="button"
+            className={styles.packButton}
+            disabled={busy || !selectedBook}
+            onClick={onGenerateChapterPack}
+          >
+            {packing
+              ? `Packing ${packProgress?.chapter ?? 0}/${packProgress?.total ?? 0}…`
+              : selectedBook
+                ? `Generate chapter pack (${selectedBook.chapters})`
+                : "Generate chapter pack"}
+          </Button>
+        ) : null}
+        {packing && onCancelChapterPack ? (
+          <button
+            type="button"
+            className={styles.packCancelButton}
+            onClick={onCancelChapterPack}
+          >
+            Cancel pack
+          </button>
+        ) : null}
       </div>
+      {packProgress ? (
+        <div className={styles.packProgress} aria-live="polite">
+          <div className={styles.packProgressTrack}>
+            <div
+              className={styles.packProgressBar}
+              style={{
+                width: `${Math.min(
+                  100,
+                  packProgress.total
+                    ? (100 * packProgress.index) / packProgress.total
+                    : 0,
+                )}%`,
+              }}
+            />
+          </div>
+          <p className={styles.helper}>{packProgress.message}</p>
+        </div>
+      ) : allowChapterPack ? (
+        <p className={styles.helper}>
+          Chapter pack creates one draft quiz per chapter (skips chapters that
+          already have a quiz for this translation). Runs in this browser — keep
+          the tab open.
+        </p>
+      ) : null}
     </section>
   );
 }

--- a/app/(admin)/admin/quizzes/QuizGeneratePanel.tsx
+++ b/app/(admin)/admin/quizzes/QuizGeneratePanel.tsx
@@ -247,6 +247,7 @@ export default function QuizGeneratePanel({
       difficulty: values.difficulty,
       focus: values.focus,
       questionTypes: values.questionTypes,
+      chapterCount: Math.max(1, values.endChapter - values.startChapter + 1),
     });
   }, [
     estimatedVerseCount,
@@ -254,6 +255,8 @@ export default function QuizGeneratePanel({
     values.difficulty,
     values.focus,
     values.questionTypes,
+    values.startChapter,
+    values.endChapter,
   ]);
 
   const suggestionKey = useMemo(() => {
@@ -551,6 +554,19 @@ export default function QuizGeneratePanel({
     setEndVerseCount(null);
   };
 
+  const handleEntireBook = () => {
+    if (!selectedBook) return;
+    autoEndVerseRef.current = true;
+    onChange({
+      startChapter: 1,
+      endChapter: selectedBook.chapters,
+      startVerse: 1,
+      endVerse: 1,
+    });
+    setStartVerseCount(null);
+    setEndVerseCount(null);
+  };
+
   const handleStartChapterSelect = (raw: string) => {
     const chapter = Number.parseInt(raw, 10);
     if (!Number.isFinite(chapter)) return;
@@ -616,8 +632,19 @@ export default function QuizGeneratePanel({
     !loadingStartVerses &&
     !(loadingEndVerses && !sameChapter);
 
+  const isEntireBook =
+    Boolean(selectedBook) &&
+    values.startChapter === 1 &&
+    values.startVerse === 1 &&
+    values.endChapter === (selectedBook?.chapters ?? 0) &&
+    endVerseCount != null &&
+    values.endVerse === endVerseCount;
+
   const verseHelper = (() => {
     if (!selectedBook) return "Pick a book to unlock chapter and verse bounds.";
+    if (isEntireBook) {
+      return `Entire ${selectedBook.name} selected (${selectedBook.chapters} chapters). Generate creates a book overview quiz (up to ${QUIZ_QUESTION_COUNT_BOUNDS.max} questions).`;
+    }
     if (loadingStartVerses || (loadingEndVerses && !sameChapter)) {
       return "Loading verse bounds…";
     }
@@ -636,8 +663,8 @@ export default function QuizGeneratePanel({
         <p className={styles.sectionEyebrow}>Passage</p>
         <h3 className={styles.sectionTitle}>Generate from scripture</h3>
         <p className={styles.sectionMeta}>
-          Choose a translation and range, tune the knobs, then generate a draft.
-          Nothing is saved until you hit Save.
+          Choose a translation and range — or an entire book for an overview
+          quiz — then generate a draft. Nothing is saved until you hit Save.
         </p>
       </div>
 
@@ -684,6 +711,53 @@ export default function QuizGeneratePanel({
             triggerClassName={controlClass}
             aria-label="Bible book"
           />
+        </div>
+
+        <div className={`${styles.field} ${styles.fieldWide}`}>
+          <span className={styles.label}>Range preset</span>
+          <div className={styles.chipGroup} role="group" aria-label="Range preset">
+            <button
+              type="button"
+              className={
+                selectedBook && !isEntireBook
+                  ? `${styles.chip} ${styles.chipActive}`
+                  : styles.chip
+              }
+              disabled={busy || !selectedBook}
+              aria-pressed={Boolean(selectedBook && !isEntireBook)}
+              onClick={() => {
+                if (!selectedBook || !isEntireBook) return;
+                autoEndVerseRef.current = true;
+                onChange({
+                  startChapter: 1,
+                  endChapter: 1,
+                  startVerse: 1,
+                  endVerse: 1,
+                });
+                setStartVerseCount(null);
+                setEndVerseCount(null);
+              }}
+            >
+              Custom range
+            </button>
+            <button
+              type="button"
+              className={
+                isEntireBook ? `${styles.chip} ${styles.chipActive}` : styles.chip
+              }
+              disabled={busy || !selectedBook}
+              aria-pressed={isEntireBook}
+              onClick={handleEntireBook}
+            >
+              Entire book
+              {selectedBook ? ` (${selectedBook.chapters} ch.)` : ""}
+            </button>
+          </div>
+          <p className={styles.helper}>
+            {isEntireBook
+              ? "Builds one overview quiz across the whole book — major people, events, and themes — not a verse-by-verse exam."
+              : "Pick chapters and verses below, or switch to Entire book for a Genesis-style overview in one step."}
+          </p>
         </div>
 
         <div className={styles.field}>
@@ -929,10 +1003,9 @@ export default function QuizGeneratePanel({
                 ) : null}
               </div>
               <p className={styles.helper}>
-                Based on about {estimatedVerseCount} verse
-                {estimatedVerseCount === 1 ? "" : "s"} in this range,{" "}
-                {values.difficulty} difficulty, and {values.focus} focus. Nudge
-                up or down if you want a shorter or deeper quiz.
+                {isEntireBook
+                  ? `Book overview across about ${estimatedVerseCount} verses in ${selectedBook?.name ?? "this book"}, ${values.difficulty} difficulty, and ${values.focus} focus. Suggests a fuller quiz near the ${QUIZ_QUESTION_COUNT_BOUNDS.max}-question cap.`
+                  : `Based on about ${estimatedVerseCount} verse${estimatedVerseCount === 1 ? "" : "s"} in this range, ${values.difficulty} difficulty, and ${values.focus} focus. Nudge up or down if you want a shorter or deeper quiz.`}
               </p>
             </>
           )}
@@ -961,7 +1034,11 @@ export default function QuizGeneratePanel({
           disabled={busy || !rangeReady}
           onClick={onGenerate}
         >
-          {generating ? "Generating…" : "Generate draft"}
+          {generating
+            ? "Generating…"
+            : isEntireBook
+              ? "Generate book overview"
+              : "Generate draft"}
         </Button>
       </div>
     </section>

--- a/app/(admin)/admin/quizzes/QuizQuestionsEditor.tsx
+++ b/app/(admin)/admin/quizzes/QuizQuestionsEditor.tsx
@@ -42,9 +42,9 @@ const TRUE_FALSE_OPTIONS = [
 const controlClass = `${styles.control} w-full min-w-0 max-w-full`;
 
 const btnSecondary =
-  "h-11 min-h-11 px-4 text-sm border-[#e0c4b6] bg-white text-[#1a1a1a] hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26] cursor-pointer";
+  "h-14 min-h-14 px-5 text-base md:h-11 md:min-h-11 md:px-4 md:text-sm border-[#e0c4b6] bg-white text-[#1a1a1a] hover:border-[#d91f26] hover:bg-[#d91f26]/10 hover:text-[#d91f26] cursor-pointer";
 const btnDanger =
-  "h-10 min-h-10 px-3 text-sm border-[#e0c4b6] bg-white text-[#d91f26] hover:border-[#d91f26] hover:bg-[#d91f26]/10 cursor-pointer";
+  "h-14 min-h-14 px-4 text-base md:h-10 md:min-h-10 md:px-3 md:text-sm border-[#e0c4b6] bg-white text-[#d91f26] hover:border-[#d91f26] hover:bg-[#d91f26]/10 cursor-pointer";
 
 const newQuestionId = () =>
   typeof crypto !== "undefined" && "randomUUID" in crypto

--- a/app/(admin)/admin/users/UsersManager.module.css
+++ b/app/(admin)/admin/users/UsersManager.module.css
@@ -124,6 +124,38 @@
   justify-content: flex-end;
 }
 
+.actions :global(button) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3.5rem;
+  height: auto;
+  padding: 0.75rem 1.15rem;
+  border-radius: 0.75rem;
+  font-size: 1rem;
+  font-weight: 650;
+}
+
+.actionButtonPrimary {
+  border: 0 !important;
+  background: linear-gradient(105deg, #d91f26, #f28c00) !important;
+  color: #ffffff !important;
+  box-shadow: 0 8px 18px color-mix(in oklab, #d91f26 24%, transparent);
+}
+
+.actionButtonPrimary:hover:not(:disabled) {
+  filter: brightness(1.03);
+  color: #ffffff !important;
+}
+
+@media (min-width: 768px) {
+  .actions :global(button) {
+    min-height: 2.5rem;
+    padding: 0.45rem 0.95rem;
+    font-size: 0.875rem;
+  }
+}
+
 .empty {
   padding: 1.5rem 1rem;
   text-align: center;

--- a/app/(admin)/admin/users/UsersManager.tsx
+++ b/app/(admin)/admin/users/UsersManager.tsx
@@ -199,6 +199,7 @@ export default function UsersManager({ initialUsers }: UsersManagerProps) {
                   <Button
                     type="button"
                     variant="outline"
+                    className={styles.actionButton}
                     disabled={!dirty || row.isSaving}
                     onClick={() => handleReset(row.id)}
                   >
@@ -206,6 +207,7 @@ export default function UsersManager({ initialUsers }: UsersManagerProps) {
                   </Button>
                   <Button
                     type="button"
+                    className={styles.actionButtonPrimary}
                     disabled={!dirty || row.isSaving}
                     onClick={() => void handleSave(row.id)}
                   >

--- a/components/admin/AdminShell.module.css
+++ b/components/admin/AdminShell.module.css
@@ -172,15 +172,17 @@
 @media (max-width: 860px) {
   .shell {
     flex-direction: column;
+    padding-top: env(safe-area-inset-top, 0px);
   }
 
   .sidebar {
-    position: sticky;
+    position: relative;
     inset: auto;
     width: 100%;
     height: auto;
     border-right: none;
     border-bottom: 1px solid var(--admin-outline);
+    z-index: 1;
   }
 
   .nav {
@@ -201,6 +203,16 @@
 
   .main {
     margin-left: 0;
+  }
+
+  /* Keep the page title in normal flow on mobile so it cannot cover
+     search fields / section headers while scrolling. */
+  .topBar {
+    position: relative;
+    top: auto;
+    z-index: 1;
+    background: var(--admin-surface-solid);
+    backdrop-filter: none;
   }
 
   .content {

--- a/lib/ai/quiz-generate.ts
+++ b/lib/ai/quiz-generate.ts
@@ -13,6 +13,10 @@ import type {
 } from "@/types/quizzes";
 
 import { getOpenAIClient, QUIZ_MODEL } from "@/lib/ai/openai";
+import {
+  buildPassagePromptPayload,
+  type PassagePromptPayload,
+} from "@/lib/quizzes/passage-prompt";
 import { suggestQuizQuestionCount } from "@/lib/quizzes/suggest-count";
 
 export {
@@ -257,13 +261,6 @@ export function normalizeGenerateRequest(
   };
 }
 
-const formatPassageForPrompt = (passage: BiblePassageResponse) =>
-  passage.verses
-    .map(({ chapter, verse, text: verseText }) =>
-      `${chapter}:${verse} ${verseText.trim()}`,
-    )
-    .join("\n");
-
 const formatRangeLabel = (
   book: string,
   start: QuizVerseRef,
@@ -408,8 +405,8 @@ type ModelQuizPayload = {
   questions?: unknown;
 };
 
-const buildSystemPrompt = () =>
-  [
+const buildSystemPrompt = (overview: boolean) => {
+  const base = [
     "You generate Bible study quizzes strictly from the provided passage text.",
     "Do not invent details that are not supported by the passage.",
     "Every question must include a citation in book chapter:verse form when possible.",
@@ -422,20 +419,37 @@ const buildSystemPrompt = () =>
     "otherwise invent a short, specific title by reasoning over the passage's main theme,",
     "people, events, or teaching — not a bare reference like \"Genesis 1:1-31\" or \"Quiz: John 3\".",
     `Keep question count between ${PLATFORM.minQuestions} and ${PLATFORM.maxQuestions}.`,
-  ].join(" ");
+  ];
+
+  if (overview) {
+    base.push(
+      "This is a BOOK or multi-chapter OVERVIEW quiz.",
+      "The passage text is a representative sample across chapters, not the complete book.",
+      "Write questions that cover major people, events, themes, and the arc of the whole range.",
+      "Spread citations across different chapters when possible.",
+      "Prefer thematic and application questions over obscure trivia that requires verses not shown.",
+      "Title the quiz as a book overview when the range covers most or all of a book (e.g. \"Genesis Overview\").",
+    );
+  }
+
+  return base.join(" ");
+};
 
 const buildUserPrompt = (
   request: QuizGenerateRequest,
-  passage: BiblePassageResponse,
   seed: number,
   targetCount: number,
+  promptPayload: PassagePromptPayload,
 ) => {
   const rangeLabel = formatRangeLabel(request.book, request.start, request.end);
   const preferredTitle = request.title?.trim();
 
   return [
     `Passage: ${rangeLabel} (${request.translation})`,
-    `Verse count: ${passage.verses.length}`,
+    `Verse count: ${promptPayload.totalVerseCount}`,
+    promptPayload.overview
+      ? `Mode: book/section overview (${promptPayload.sampledVerseCount} sample verses across ${promptPayload.chapterCount} chapters)`
+      : "Mode: full passage",
     `Difficulty: ${request.difficulty}`,
     `Focus: ${request.focus}`,
     `Allowed question types: ${request.questionTypes.join(", ")}`,
@@ -445,14 +459,15 @@ const buildUserPrompt = (
       ? `Preferred title (use this): ${preferredTitle}`
       : [
           "Title: none provided.",
-          "Read the passage, identify its central theme or moment,",
-          "and invent a concise quiz title (about 3–8 words) that reflects that content.",
-          "Examples of good style: \"Light in the Darkness\", \"The Good Samaritan\", \"Faith Without Works\".",
+          promptPayload.overview
+            ? "Invent a concise overview title that names the book or section (about 3–8 words)."
+            : "Read the passage, identify its central theme or moment, and invent a concise quiz title (about 3–8 words) that reflects that content.",
+          "Examples of good style: \"Light in the Darkness\", \"The Good Samaritan\", \"Genesis Overview\".",
           "Do not use only the book/chapter/verse reference as the title.",
         ].join(" "),
     "",
-    "Passage text:",
-    formatPassageForPrompt(passage),
+    promptPayload.overview ? "Passage sample (overview):" : "Passage text:",
+    promptPayload.text,
     "",
     "Respond with JSON:",
     '{ "title": string, "suggestedQuestionCount": number, "questions": [',
@@ -495,8 +510,11 @@ export async function generateQuizFromPassage(
     difficulty: request.difficulty,
     focus: request.focus,
     questionTypes: request.questionTypes,
+    chapterCount:
+      request.end.chapter - request.start.chapter + 1,
   });
   const targetCount = request.questionCount ?? heuristicCount;
+  const promptPayload = buildPassagePromptPayload(passage);
 
   const client = getOpenAIClient();
   let completion;
@@ -507,10 +525,15 @@ export async function generateQuizFromPassage(
       seed,
       response_format: { type: "json_object" },
       messages: [
-        { role: "system", content: buildSystemPrompt() },
+        { role: "system", content: buildSystemPrompt(promptPayload.overview) },
         {
           role: "user",
-          content: buildUserPrompt(request, passage, seed, targetCount),
+          content: buildUserPrompt(
+            request,
+            seed,
+            targetCount,
+            promptPayload,
+          ),
         },
       ],
     });

--- a/lib/quizzes/chapter-pack.ts
+++ b/lib/quizzes/chapter-pack.ts
@@ -1,0 +1,80 @@
+import type { Quiz } from "@/types/quizzes";
+
+export type ChapterPackJob = {
+  chapter: number;
+  /** Prefer omitting so the generate API sizes each chapter itself. */
+  titleHint: string;
+};
+
+export type ChapterPackPlan = {
+  book: string;
+  translation: string;
+  chapterCount: number;
+  jobs: ChapterPackJob[];
+};
+
+/** Build one generate job per chapter in the book. */
+export function planChapterPack(options: {
+  book: string;
+  translation: string;
+  chapterCount: number;
+}): ChapterPackPlan {
+  const chapterCount = Math.max(0, Math.floor(options.chapterCount));
+  const jobs: ChapterPackJob[] = [];
+  for (let chapter = 1; chapter <= chapterCount; chapter += 1) {
+    jobs.push({
+      chapter,
+      titleHint: `${options.book} ${chapter}`,
+    });
+  }
+  return {
+    book: options.book,
+    translation: options.translation,
+    chapterCount,
+    jobs,
+  };
+}
+
+/**
+ * True when an existing quiz already covers exactly this single chapter
+ * (any verse span inside the chapter). Archived quizzes do not block.
+ */
+export function hasExistingChapterQuiz(
+  quizzes: Array<
+    Pick<
+      Quiz,
+      | "book"
+      | "translation_code"
+      | "start_chapter"
+      | "end_chapter"
+      | "status"
+    >
+  >,
+  options: {
+    book: string;
+    translation: string;
+    chapter: number;
+  },
+): boolean {
+  const book = options.book.trim().toLowerCase();
+  const translation = options.translation.trim().toUpperCase();
+  return quizzes.some(
+    (quiz) =>
+      quiz.status !== "archived" &&
+      quiz.book.trim().toLowerCase() === book &&
+      quiz.translation_code.trim().toUpperCase() === translation &&
+      quiz.start_chapter === options.chapter &&
+      quiz.end_chapter === options.chapter,
+  );
+}
+
+export type ChapterPackProgress = {
+  status: "running" | "done" | "cancelled";
+  total: number;
+  index: number;
+  chapter: number;
+  created: number;
+  skipped: number;
+  failed: number;
+  message: string;
+};

--- a/lib/quizzes/passage-prompt.ts
+++ b/lib/quizzes/passage-prompt.ts
@@ -1,0 +1,134 @@
+import type {
+  BiblePassageResponse,
+  BiblePassageVerse,
+} from "@/types/bible";
+
+/** Full text is fine for short/medium passages; larger spans use overview sampling. */
+export const FULL_PROMPT_VERSE_LIMIT = 80;
+
+/** Soft cap on verses sent to the model for book/section overviews. */
+export const OVERVIEW_SAMPLE_VERSE_LIMIT = 120;
+
+/** Prefer a few verses from each chapter so coverage spans the book. */
+export const OVERVIEW_VERSES_PER_CHAPTER = 4;
+
+export type PassagePromptPayload = {
+  text: string;
+  overview: boolean;
+  sampledVerseCount: number;
+  totalVerseCount: number;
+  chapterCount: number;
+};
+
+const groupVersesByChapter = (verses: BiblePassageVerse[]) => {
+  const byChapter = new Map<number, BiblePassageVerse[]>();
+  for (const verse of verses) {
+    const list = byChapter.get(verse.chapter) ?? [];
+    list.push(verse);
+    byChapter.set(verse.chapter, list);
+  }
+  return byChapter;
+};
+
+/**
+ * Pick evenly spaced verses from a chapter so overview quizzes cover
+ * beginning, middle, and end rather than only the opening lines.
+ */
+export function sampleChapterVerses(
+  chapterVerses: BiblePassageVerse[],
+  limit = OVERVIEW_VERSES_PER_CHAPTER,
+): BiblePassageVerse[] {
+  if (chapterVerses.length <= limit) {
+    return chapterVerses;
+  }
+
+  if (limit <= 1) {
+    return [chapterVerses[0]];
+  }
+
+  const sampled: BiblePassageVerse[] = [];
+  const lastIndex = chapterVerses.length - 1;
+  for (let i = 0; i < limit; i += 1) {
+    const index =
+      i === limit - 1
+        ? lastIndex
+        : Math.round((i * lastIndex) / (limit - 1));
+    const verse = chapterVerses[index];
+    if (!sampled.some((item) => item.verse === verse.verse)) {
+      sampled.push(verse);
+    }
+  }
+  return sampled;
+}
+
+export function isOverviewPassage(passage: BiblePassageResponse): boolean {
+  const chapterSpan =
+    passage.range.end.chapter - passage.range.start.chapter + 1;
+  return (
+    passage.verses.length > FULL_PROMPT_VERSE_LIMIT || chapterSpan >= 4
+  );
+}
+
+const formatVerseLine = (verse: BiblePassageVerse) =>
+  `${verse.chapter}:${verse.verse} ${verse.text.trim()}`;
+
+/**
+ * Build the scripture block for the quiz generation prompt.
+ * Short ranges get the full text; book-scale ranges get a stratified sample
+ * so Genesis-sized requests stay within model context.
+ */
+export function buildPassagePromptPayload(
+  passage: BiblePassageResponse,
+): PassagePromptPayload {
+  const totalVerseCount = passage.verses.length;
+  const byChapter = groupVersesByChapter(passage.verses);
+  const chapterCount = byChapter.size;
+
+  if (!isOverviewPassage(passage)) {
+    return {
+      text: passage.verses.map(formatVerseLine).join("\n"),
+      overview: false,
+      sampledVerseCount: totalVerseCount,
+      totalVerseCount,
+      chapterCount,
+    };
+  }
+
+  const perChapter = Math.max(
+    1,
+    Math.min(
+      OVERVIEW_VERSES_PER_CHAPTER,
+      Math.floor(OVERVIEW_SAMPLE_VERSE_LIMIT / Math.max(chapterCount, 1)),
+    ),
+  );
+
+  const sampled: BiblePassageVerse[] = [];
+  const chapterNumbers = [...byChapter.keys()].sort((a, b) => a - b);
+  for (const chapter of chapterNumbers) {
+    sampled.push(
+      ...sampleChapterVerses(byChapter.get(chapter) ?? [], perChapter),
+    );
+  }
+
+  const capped = sampled.slice(0, OVERVIEW_SAMPLE_VERSE_LIMIT);
+  const lines: string[] = [
+    `[Overview sample: ${capped.length} of ${totalVerseCount} verses across ${chapterCount} chapters. Questions should cover the arc of the whole range.]`,
+  ];
+
+  let currentChapter: number | null = null;
+  for (const verse of capped) {
+    if (verse.chapter !== currentChapter) {
+      currentChapter = verse.chapter;
+      lines.push(`--- Chapter ${currentChapter} ---`);
+    }
+    lines.push(formatVerseLine(verse));
+  }
+
+  return {
+    text: lines.join("\n"),
+    overview: true,
+    sampledVerseCount: capped.length,
+    totalVerseCount,
+    chapterCount,
+  };
+}

--- a/lib/quizzes/suggest-count.ts
+++ b/lib/quizzes/suggest-count.ts
@@ -35,9 +35,21 @@ export function suggestQuizQuestionCount(options: {
   difficulty?: QuizDifficulty;
   focus?: QuizFocus;
   questionTypes?: QuizQuestionType[];
+  /** When set, multi-chapter / book spans lean toward fuller overview quizzes. */
+  chapterCount?: number;
 }): number {
   const verseCount = Math.max(0, Math.floor(options.verseCount));
+  const chapterCount = Math.max(1, Math.floor(options.chapterCount ?? 1));
   let count = baseCountFromVerseCount(verseCount);
+
+  // Book/section overviews should sit near the top of the allowed band.
+  if (chapterCount >= 20 || verseCount >= 800) {
+    count = Math.max(count, 18);
+  } else if (chapterCount >= 8 || verseCount >= 200) {
+    count = Math.max(count, 16);
+  } else if (chapterCount >= 4 || verseCount >= 80) {
+    count = Math.max(count, 14);
+  }
 
   if (options.difficulty === "easy") count -= 1;
   if (options.difficulty === "hard") count += 2;
@@ -50,7 +62,9 @@ export function suggestQuizQuestionCount(options: {
   if (typeCount >= 3) count += 1;
 
   // Very short passages cannot support a large quiz well.
-  if (verseCount > 0) {
+  // Skip this clamp for multi-chapter overviews where verseCount is large
+  // but questions intentionally sample themes rather than every verse.
+  if (verseCount > 0 && chapterCount < 4 && verseCount < 80) {
     count = Math.min(count, Math.max(MIN_QUESTIONS, verseCount + 2));
   }
 

--- a/tests/chapterPack.test.mjs
+++ b/tests/chapterPack.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { loadTsModule } from "./utils/load-ts-module.mjs";
+
+const load = async () => loadTsModule("lib/quizzes/chapter-pack.ts");
+
+describe("chapter pack planning", () => {
+  it("plans one job per chapter", async () => {
+    const { planChapterPack } = await load();
+    const plan = planChapterPack({
+      book: "Genesis",
+      translation: "WEB",
+      chapterCount: 3,
+    });
+    assert.equal(plan.chapterCount, 3);
+    assert.equal(plan.jobs.length, 3);
+    assert.deepEqual(
+      plan.jobs.map((job) => job.chapter),
+      [1, 2, 3],
+    );
+    assert.equal(plan.jobs[1].titleHint, "Genesis 2");
+  });
+
+  it("detects existing single-chapter quizzes", async () => {
+    const { hasExistingChapterQuiz } = await load();
+    const quizzes = [
+      {
+        book: "Genesis",
+        translation_code: "WEB",
+        start_chapter: 12,
+        end_chapter: 12,
+        status: "draft",
+      },
+      {
+        book: "Genesis",
+        translation_code: "WEB",
+        start_chapter: 1,
+        end_chapter: 3,
+        status: "published",
+      },
+      {
+        book: "Genesis",
+        translation_code: "WEB",
+        start_chapter: 5,
+        end_chapter: 5,
+        status: "archived",
+      },
+    ];
+
+    assert.equal(
+      hasExistingChapterQuiz(quizzes, {
+        book: "Genesis",
+        translation: "web",
+        chapter: 12,
+      }),
+      true,
+    );
+    assert.equal(
+      hasExistingChapterQuiz(quizzes, {
+        book: "Genesis",
+        translation: "WEB",
+        chapter: 1,
+      }),
+      false,
+    );
+    assert.equal(
+      hasExistingChapterQuiz(quizzes, {
+        book: "Genesis",
+        translation: "WEB",
+        chapter: 5,
+      }),
+      false,
+    );
+  });
+});

--- a/tests/passagePrompt.test.mjs
+++ b/tests/passagePrompt.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { loadTsModule } from "./utils/load-ts-module.mjs";
+
+const loadPassagePrompt = async () =>
+  loadTsModule("lib/quizzes/passage-prompt.ts");
+
+const loadSuggestCount = async () =>
+  loadTsModule("lib/quizzes/suggest-count.ts");
+
+const makePassage = ({
+  chapters,
+  versesPerChapter = 10,
+}) => {
+  const verses = [];
+  for (let chapter = 1; chapter <= chapters; chapter += 1) {
+    for (let verse = 1; verse <= versesPerChapter; verse += 1) {
+      verses.push({
+        chapter,
+        verse,
+        text: `Chapter ${chapter} verse ${verse} text.`,
+      });
+    }
+  }
+
+  return {
+    translation: { code: "WEB", name: "World English Bible" },
+    book: {
+      id: "genesis",
+      name: "Genesis",
+      abbreviation: "Gen",
+      chapters,
+    },
+    range: {
+      start: { chapter: 1, verse: 1 },
+      end: { chapter: chapters, verse: versesPerChapter },
+    },
+    verses,
+  };
+};
+
+describe("passage prompt overview sampling", () => {
+  it("keeps short passages as full text", async () => {
+    const { buildPassagePromptPayload, isOverviewPassage } =
+      await loadPassagePrompt();
+    const passage = makePassage({ chapters: 1, versesPerChapter: 20 });
+
+    assert.equal(isOverviewPassage(passage), false);
+    const payload = buildPassagePromptPayload(passage);
+    assert.equal(payload.overview, false);
+    assert.equal(payload.sampledVerseCount, 20);
+    assert.match(payload.text, /^1:1 /);
+    assert.doesNotMatch(payload.text, /Overview sample/);
+  });
+
+  it("samples evenly across many chapters for book overviews", async () => {
+    const {
+      buildPassagePromptPayload,
+      isOverviewPassage,
+      OVERVIEW_SAMPLE_VERSE_LIMIT,
+    } = await loadPassagePrompt();
+    const passage = makePassage({ chapters: 50, versesPerChapter: 30 });
+
+    assert.equal(isOverviewPassage(passage), true);
+    const payload = buildPassagePromptPayload(passage);
+    assert.equal(payload.overview, true);
+    assert.equal(payload.totalVerseCount, 1500);
+    assert.ok(payload.sampledVerseCount <= OVERVIEW_SAMPLE_VERSE_LIMIT);
+    assert.ok(payload.sampledVerseCount < payload.totalVerseCount);
+    assert.match(payload.text, /Overview sample/);
+    assert.match(payload.text, /--- Chapter 1 ---/);
+    assert.match(payload.text, /--- Chapter 50 ---/);
+  });
+
+  it("samples beginning and end within a chapter", async () => {
+    const { sampleChapterVerses } = await loadPassagePrompt();
+    const chapterVerses = Array.from({ length: 10 }, (_v, i) => ({
+      chapter: 3,
+      verse: i + 1,
+      text: `v${i + 1}`,
+    }));
+
+    const sampled = sampleChapterVerses(chapterVerses, 4);
+    assert.equal(sampled[0].verse, 1);
+    assert.equal(sampled[sampled.length - 1].verse, 10);
+    assert.equal(sampled.length, 4);
+  });
+});
+
+describe("suggestQuizQuestionCount for book spans", () => {
+  it("suggests a fuller quiz for entire-book sized ranges", async () => {
+    const { suggestQuizQuestionCount, QUIZ_QUESTION_COUNT_BOUNDS } =
+      await loadSuggestCount();
+
+    const bookCount = suggestQuizQuestionCount({
+      verseCount: 1500,
+      chapterCount: 50,
+      difficulty: "medium",
+      focus: "mixed",
+      questionTypes: ["multiple_choice", "short_answer"],
+    });
+
+    assert.ok(bookCount >= 16);
+    assert.ok(bookCount <= QUIZ_QUESTION_COUNT_BOUNDS.max);
+  });
+
+  it("still keeps short passages small", async () => {
+    const { suggestQuizQuestionCount } = await loadSuggestCount();
+    const shortCount = suggestQuizQuestionCount({
+      verseCount: 4,
+      chapterCount: 1,
+      difficulty: "medium",
+      focus: "factual",
+      questionTypes: ["multiple_choice"],
+    });
+    assert.equal(shortCount, 3);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Follow-up to book overview: admins can generate a **chapter pack** — one draft quiz per chapter for a whole book (e.g. Genesis 1–50).

**Already merged to `staging`.**

## How it works
1. `/admin/quizzes/new` → pick translation + book
2. Tap **Generate chapter pack (N)**
3. Confirm → progress bar runs chapter by chapter in the browser
4. Skips chapters that already have a quiz for that translation
5. Cancel anytime; then opens the quizzes list

Uses the existing generate + create APIs sequentially (avoids serverless timeouts on 50+ chapter books).

## Staging preview
https://sword-git-staging-grimmzs-projects.vercel.app  
Deployment: https://sword-qbabb6hla-grimmzs-projects.vercel.app

## QA
`/admin/quizzes/new` → pick a short book first (e.g. Jude / Obadiah) → Generate chapter pack → confirm drafts appear. Then try cancel mid-pack on a longer book.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc26e-e0a8-750f-a978-78cccc5252e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc26e-e0a8-750f-a978-78cccc5252e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

