### PR TITLE
Add quiz unpublish and attempt reset controls

### DIFF
--- a/app/(admin)/admin/quizzes/QuizScoresPanel.module.css
+++ b/app/(admin)/admin/quizzes/QuizScoresPanel.module.css
@@ -4,6 +4,75 @@
   gap: 1.25rem;
 }
 
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+  padding: 1rem 1.15rem;
+  border-radius: 1rem;
+  border: 1px solid #e8cfc4;
+  background: color-mix(in oklab, #fff5f0 70%, #ffffff);
+}
+
+.toolbarCopy {
+  margin: 0;
+  flex: 1;
+  min-width: 12rem;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: #4a4a4a;
+}
+
+.resetAllButton,
+.resetUserButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.55rem 1rem;
+  border-radius: 0.75rem;
+  border: 1.5px solid #e0c4b6;
+  background: #ffffff;
+  color: #d91f26;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 650;
+  cursor: pointer;
+  transition:
+    border-color 150ms ease,
+    background 150ms ease;
+}
+
+.resetAllButton:hover:not(:disabled),
+.resetUserButton:hover:not(:disabled) {
+  border-color: #d91f26;
+  background: color-mix(in oklab, #d91f26 8%, #ffffff);
+}
+
+.resetAllButton:disabled,
+.resetUserButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.detailActions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+@media (max-width: 719px) {
+  .resetAllButton,
+  .resetUserButton {
+    width: 100%;
+    min-height: 3.5rem;
+  }
+}
+
 .empty {
   margin: 0;
   padding: 1.25rem 1.35rem;

--- a/app/(admin)/admin/quizzes/QuizScoresPanel.tsx
+++ b/app/(admin)/admin/quizzes/QuizScoresPanel.tsx
@@ -1,9 +1,15 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
 import { ChevronDown, ChevronUp } from "lucide-react";
+import { toast } from "sonner";
 
-import { getAdminQuizUserAttempts } from "@/lib/api/admin-quizzes";
+import {
+  getAdminQuizUserAttempts,
+  resetAdminQuizScores,
+  resetAdminQuizUserAttempts,
+} from "@/lib/api/admin-quizzes";
 import { ApiError } from "@/lib/api/fetch";
 import type {
   AdminQuizAttemptRow,
@@ -45,16 +51,19 @@ export default function QuizScoresPanel({
   scores,
   summary,
 }: QuizScoresPanelProps) {
+  const router = useRouter();
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [attemptsByUser, setAttemptsByUser] = useState<
     Record<string, AdminQuizAttemptRow[]>
   >({});
   const [loadingUserId, setLoadingUserId] = useState<string | null>(null);
   const [errorByUser, setErrorByUser] = useState<Record<string, string>>({});
+  const [resettingUserId, setResettingUserId] = useState<string | null>(null);
+  const [resettingAll, setResettingAll] = useState(false);
 
   const loadAttempts = useCallback(
-    async (userId: string) => {
-      if (attemptsByUser[userId]) return;
+    async (userId: string, force = false) => {
+      if (!force && attemptsByUser[userId]) return;
 
       setLoadingUserId(userId);
       setErrorByUser((prev) => {
@@ -88,8 +97,82 @@ export default function QuizScoresPanel({
     void loadAttempts(userId);
   };
 
+  const handleResetUser = async (row: AdminQuizScoreRow) => {
+    const confirmed = window.confirm(
+      `Reset attempts for ${row.displayName}?\n\nThis deletes their ${row.attemptCount} attempt${row.attemptCount === 1 ? "" : "s"} and score for this quiz. They can take it again from scratch.`,
+    );
+    if (!confirmed) return;
+
+    setResettingUserId(row.userId);
+    try {
+      await resetAdminQuizUserAttempts(quizId, row.userId);
+      toast.success(`Reset attempts for ${row.displayName}`);
+      setAttemptsByUser((prev) => {
+        const next = { ...prev };
+        delete next[row.userId];
+        return next;
+      });
+      if (expandedId === row.userId) setExpandedId(null);
+      router.refresh();
+    } catch (error) {
+      const message =
+        error instanceof ApiError
+          ? error.message
+          : "Failed to reset member attempts";
+      toast.error(message);
+    } finally {
+      setResettingUserId(null);
+    }
+  };
+
+  const handleResetAll = async () => {
+    if (scores.length === 0) return;
+    const confirmed = window.confirm(
+      `Reset ALL scores for this quiz?\n\nThis deletes attempts and scores for ${summary.memberCount} member${summary.memberCount === 1 ? "" : "s"}. This cannot be undone.`,
+    );
+    if (!confirmed) return;
+
+    setResettingAll(true);
+    try {
+      const result = await resetAdminQuizScores(quizId);
+      toast.success(
+        `Reset ${result.deletedScores} score${result.deletedScores === 1 ? "" : "s"} (${result.deletedAttempts} attempt${result.deletedAttempts === 1 ? "" : "s"})`,
+      );
+      setAttemptsByUser({});
+      setExpandedId(null);
+      router.refresh();
+    } catch (error) {
+      const message =
+        error instanceof ApiError
+          ? error.message
+          : "Failed to reset quiz scores";
+      toast.error(message);
+    } finally {
+      setResettingAll(false);
+    }
+  };
+
+  const busy = resettingAll || resettingUserId !== null;
+
   return (
     <div className={styles.panel}>
+      <div className={styles.toolbar}>
+        <p className={styles.toolbarCopy}>
+          Unpublishing hides the quiz but keeps scores. Reset clears attempt
+          limits so members can start over.
+        </p>
+        {scores.length > 0 ? (
+          <button
+            type="button"
+            className={styles.resetAllButton}
+            disabled={busy}
+            onClick={() => void handleResetAll()}
+          >
+            {resettingAll ? "Resetting…" : "Reset all attempts"}
+          </button>
+        ) : null}
+      </div>
+
       <div className={pageStyles.statsRow}>
         <div className={pageStyles.statCard}>
           <p className={pageStyles.statLabel}>Members</p>
@@ -121,6 +204,7 @@ export default function QuizScoresPanel({
             const attempts = attemptsByUser[row.userId];
             const loading = loadingUserId === row.userId;
             const error = errorByUser[row.userId];
+            const resetting = resettingUserId === row.userId;
 
             return (
               <article key={row.userId} className={styles.row}>
@@ -187,6 +271,18 @@ export default function QuizScoresPanel({
 
                 {expanded ? (
                   <div className={styles.detail}>
+                    <div className={styles.detailActions}>
+                      <button
+                        type="button"
+                        className={styles.resetUserButton}
+                        disabled={busy}
+                        onClick={() => void handleResetUser(row)}
+                      >
+                        {resetting
+                          ? "Resetting…"
+                          : "Reset this member’s attempts"}
+                      </button>
+                    </div>
                     {loading ? (
                       <p className={styles.detailLoading}>Loading attempts…</p>
                     ) : null}

--- a/app/(admin)/admin/quizzes/QuizzesList.tsx
+++ b/app/(admin)/admin/quizzes/QuizzesList.tsx
@@ -65,11 +65,32 @@ export default function QuizzesList({ quizzes }: QuizzesListProps) {
     }
   };
 
+  const handleUnpublish = async (quiz: Quiz) => {
+    const confirmed = window.confirm(
+      `Unpublish “${quiz.title}”?\n\nMembers will no longer see it. Their scores and attempts are kept — use Scores → Reset if you want a clean slate.`,
+    );
+    if (!confirmed) return;
+
+    setPendingId(quiz.id);
+    try {
+      await setAdminQuizStatus(quiz.id, "draft");
+      toast.success(`Unpublished “${quiz.title}”`);
+      router.refresh();
+    } catch (error: unknown) {
+      const message =
+        error instanceof ApiError ? error.message : "Failed to unpublish quiz";
+      toast.error(message);
+    } finally {
+      setPendingId(null);
+    }
+  };
+
   return (
     <section className={styles.listStack} aria-label="All quizzes">
       {quizzes.map((quiz) => {
         const status = getStatus(quiz.status);
-        const publishing = pendingId === quiz.id;
+        const pending = pendingId === quiz.id;
+        const isPublished = quiz.status === "published";
         const canPublish = quiz.status !== "published";
 
         return (
@@ -101,10 +122,20 @@ export default function QuizzesList({ quizzes }: QuizzesListProps) {
                   <button
                     type="button"
                     className={styles.listCardButton}
-                    disabled={publishing || pendingId !== null}
+                    disabled={pending || pendingId !== null}
                     onClick={() => void handlePublish(quiz)}
                   >
-                    {publishing ? "Publishing…" : "Publish"}
+                    {pending ? "Publishing…" : "Publish"}
+                  </button>
+                ) : null}
+                {isPublished ? (
+                  <button
+                    type="button"
+                    className={styles.listCardLink}
+                    disabled={pending || pendingId !== null}
+                    onClick={() => void handleUnpublish(quiz)}
+                  >
+                    {pending ? "Unpublishing…" : "Unpublish"}
                   </button>
                 ) : null}
                 <Link

--- a/app/api/admin/quizzes/[id]/scores/[userId]/route.ts
+++ b/app/api/admin/quizzes/[id]/scores/[userId]/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server";
 
 import { requireAdminOnly } from "@/lib/admin/auth";
-import { listAdminQuizAttemptsForUser } from "@/lib/quizzes/admin-scores";
+import {
+  listAdminQuizAttemptsForUser,
+  resetAdminQuizScoresForUser,
+} from "@/lib/quizzes/admin-scores";
 import { getServiceRoleClient } from "@/lib/supabase/admin";
 
 type RouteContext = {
@@ -35,6 +38,43 @@ export async function GET(request: Request, context: RouteContext) {
           error instanceof Error
             ? error.message
             : "Failed to load quiz attempts",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+/** DELETE — reset one member's attempts/scores for this quiz. */
+export async function DELETE(request: Request, context: RouteContext) {
+  const auth = await requireAdminOnly(request);
+  if (auth.error) return auth.error;
+
+  const { id, userId } = await context.params;
+  if (!id || !userId) {
+    return NextResponse.json(
+      { error: "Quiz id and user id are required" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const admin = getServiceRoleClient();
+    const result = await resetAdminQuizScoresForUser(admin, id, userId);
+    if (!result) {
+      return NextResponse.json({ error: "Quiz not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      ok: true as const,
+      deletedAttempts: result.deletedAttempts,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to reset member attempts",
       },
       { status: 500 },
     );

--- a/app/api/admin/quizzes/[id]/scores/route.ts
+++ b/app/api/admin/quizzes/[id]/scores/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { requireAdminOnly } from "@/lib/admin/auth";
 import {
   listAdminQuizScores,
+  resetAdminQuizScores,
   summarizeAdminQuizScores,
 } from "@/lib/quizzes/admin-scores";
 import { getServiceRoleClient } from "@/lib/supabase/admin";
@@ -37,6 +38,41 @@ export async function GET(request: Request, context: RouteContext) {
       {
         error:
           error instanceof Error ? error.message : "Failed to load quiz scores",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+/** DELETE /api/admin/quizzes/[id]/scores — reset all member attempts/scores. */
+export async function DELETE(request: Request, context: RouteContext) {
+  const auth = await requireAdminOnly(request);
+  if (auth.error) return auth.error;
+
+  const { id } = await context.params;
+  if (!id) {
+    return NextResponse.json({ error: "Quiz id is required" }, { status: 400 });
+  }
+
+  try {
+    const admin = getServiceRoleClient();
+    const result = await resetAdminQuizScores(admin, id);
+    if (!result) {
+      return NextResponse.json({ error: "Quiz not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      ok: true as const,
+      deletedScores: result.deletedScores,
+      deletedAttempts: result.deletedAttempts,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to reset quiz scores",
       },
       { status: 500 },
     );

--- a/lib/api/admin-quizzes.ts
+++ b/lib/api/admin-quizzes.ts
@@ -60,7 +60,22 @@ export const getAdminQuizScores = (id: string) =>
     summary: AdminQuizScoresSummary;
   }>(`/api/admin/quizzes/${id}/scores`);
 
+export const resetAdminQuizScores = (id: string) =>
+  apiFetch<{
+    ok: true;
+    deletedScores: number;
+    deletedAttempts: number;
+  }>(`/api/admin/quizzes/${id}/scores`, {
+    method: "DELETE",
+  });
+
 export const getAdminQuizUserAttempts = (quizId: string, userId: string) =>
   apiFetch<{ attempts: AdminQuizAttemptRow[] }>(
     `/api/admin/quizzes/${quizId}/scores/${userId}`,
+  );
+
+export const resetAdminQuizUserAttempts = (quizId: string, userId: string) =>
+  apiFetch<{ ok: true; deletedAttempts: number }>(
+    `/api/admin/quizzes/${quizId}/scores/${userId}`,
+    { method: "DELETE" },
   );

--- a/lib/quizzes/admin-scores.ts
+++ b/lib/quizzes/admin-scores.ts
@@ -242,3 +242,69 @@ export async function listAdminQuizAttemptsForUser(
     answers: parseStoredAnswers(row.answers, questionsById),
   }));
 }
+
+/**
+ * Delete one member's attempt history + score row for a quiz so they can
+ * take it again from a clean slate.
+ */
+export async function resetAdminQuizScoresForUser(
+  client: Client,
+  quizId: string,
+  userId: string,
+): Promise<{ quiz: Quiz; deletedAttempts: number } | null> {
+  const quiz = await getAdminQuiz(client, quizId);
+  if (!quiz) return null;
+
+  const { data: attempts, error: attemptsError } = await client
+    .from("quiz_attempts")
+    .delete()
+    .eq("quiz_id", quizId)
+    .eq("user_id", userId)
+    .select("id");
+
+  if (attemptsError) throw new Error(attemptsError.message);
+
+  const { error: scoresError } = await client
+    .from("quiz_scores")
+    .delete()
+    .eq("quiz_id", quizId)
+    .eq("user_id", userId);
+
+  if (scoresError) throw new Error(scoresError.message);
+
+  return {
+    quiz,
+    deletedAttempts: (attempts ?? []).length,
+  };
+}
+
+/** Delete every member's attempts + scores for a quiz. */
+export async function resetAdminQuizScores(
+  client: Client,
+  quizId: string,
+): Promise<{ quiz: Quiz; deletedScores: number; deletedAttempts: number } | null> {
+  const quiz = await getAdminQuiz(client, quizId);
+  if (!quiz) return null;
+
+  const { data: attempts, error: attemptsError } = await client
+    .from("quiz_attempts")
+    .delete()
+    .eq("quiz_id", quizId)
+    .select("id");
+
+  if (attemptsError) throw new Error(attemptsError.message);
+
+  const { data: scores, error: scoresError } = await client
+    .from("quiz_scores")
+    .delete()
+    .eq("quiz_id", quizId)
+    .select("id");
+
+  if (scoresError) throw new Error(scoresError.message);
+
+  return {
+    quiz,
+    deletedScores: (scores ?? []).length,
+    deletedAttempts: (attempts ?? []).length,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Clarify quiz attempt lifecycle for admins:

- **Unpublish** hides a quiz from members (status → draft) but **keeps scores/attempts**
- **Reset attempts** clears scores so members can retake (per-user or all)

Already merged to `staging`.

## How attempts work
Each member gets `max_attempts` (default 3). After that their best score locks. Unpublish does not unlock them — use Reset on the Scores page.

## Changes
- List: **Unpublish** on published quizzes
- Scores: **Reset this member’s attempts** + **Reset all attempts**
- APIs: `DELETE /api/admin/quizzes/[id]/scores` and `.../scores/[userId]`

## Staging
https://sword-git-staging-grimmzs-projects.vercel.app

## QA
1. Publish a quiz, take it as a member until locked
2. Unpublish → quiz hidden, score still on Scores page
3. Reset that member → they can take again after republish
4. Reset all → clears everyone
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc26e-e0a8-750f-a978-78cccc5252e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc26e-e0a8-750f-a978-78cccc5252e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

