### PR TITLE
Add book typeahead to reader, notes, and memory pickers

### DIFF
--- a/components/BibleReaderScreen.module.css
+++ b/components/BibleReaderScreen.module.css
@@ -320,9 +320,11 @@
 
 .titleSelect {
   width: 100%;
-  min-height: auto;
+  min-height: auto !important;
+  height: auto !important;
   padding: 0 1.5rem 0 0 !important;
   border: none !important;
+  border-radius: 0 !important;
   background: transparent !important;
   box-shadow: none !important;
   font-size: clamp(1.125rem, 5vw, 1.5rem);
@@ -331,7 +333,20 @@
   line-height: 1.2;
 }
 
-.titleSelect :global([data-slot="select-value"]) {
+.titleSelect:hover:not(:disabled),
+.titleSelect:focus-visible {
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.titleSelect:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--primary) 35%, transparent);
+  outline-offset: 2px;
+}
+
+.titleSelect :global([data-slot="select-value"]),
+.titleSelect > span:first-of-type {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/components/BibleReaderScreen.tsx
+++ b/components/BibleReaderScreen.tsx
@@ -36,9 +36,9 @@ import {
 } from "./ui/select";
 import { Separator } from "./ui/separator";
 import { Textarea } from "./ui/textarea";
+import { BookCombobox } from "@/components/bible/BookCombobox";
 import { LoadingScreen } from "@/components/LoadingScreen";
 import { AppHeaderToolbar } from "@/components/AppHeaderToolbar";
-import bibleSelectStyles from "@/components/TranslationSwitcher.module.css";
 import { buildReferenceLabel } from "@/lib/api/bible";
 import { useChapterQuery } from "@/lib/query/bible";
 import {
@@ -633,34 +633,22 @@ export function BibleReaderScreen() {
       <div className={styles.toolbar}>
         <div className={styles.headerRow}>
           <div className={styles.titleBlock}>
-            <Select
+            <BookCombobox
+              books={books}
               value={selectedBookId ?? undefined}
+              valueKey="id"
               onValueChange={(value) => {
                 setPosition(value, 1);
               }}
               disabled={books.length === 0}
-            >
-              <SelectTrigger
-                className={clsx(styles.selectTriggerBase, styles.titleSelect)}
-                aria-label="Choose book"
-              >
-                <SelectValue placeholder="Scripture" />
-              </SelectTrigger>
-              <SelectContent
-                className={bibleSelectStyles.selectContent}
-                sideOffset={6}
-              >
-                {books.map((book) => (
-                  <SelectItem
-                    key={book.id}
-                    value={book.id}
-                    className={bibleSelectStyles.selectItem}
-                  >
-                    {book.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              placeholder="Scripture"
+              searchPlaceholder="Search books…"
+              aria-label="Choose book"
+              triggerClassName={clsx(
+                styles.selectTriggerBase,
+                styles.titleSelect,
+              )}
+            />
           </div>
 
           <AppHeaderToolbar />

--- a/components/MemoryScreen.tsx
+++ b/components/MemoryScreen.tsx
@@ -46,6 +46,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "./ui/select";
+import { BookCombobox } from "@/components/bible/BookCombobox";
 import { buildReferenceLabel } from "@/lib/api/bible";
 import { LoadingScreen } from "@/components/LoadingScreen";
 import {
@@ -637,32 +638,21 @@ export function MemoryScreen({ onNavigate }: MemoryScreenProps = {}) {
                     >
                       <div className={styles.fieldGroup}>
                         <span className={styles.fieldLabel}>Book</span>
-                        <Select
+                        <BookCombobox
+                          books={books}
                           value={createBookId ?? undefined}
+                          valueKey="id"
                           onValueChange={(value) => {
                             setCreateBookId(value);
                             setCreateChapter("1");
                             setCreateVerseStart("1");
                             setCreateVerseEnd("1");
                           }}
-                        >
-                          <SelectTrigger className={styles.selectTrigger}>
-                            <SelectValue placeholder="Select book" />
-                          </SelectTrigger>
-                          <SelectContent
-                            className={`${styles.selectContent} z-[9999]`}
-                          >
-                            {books.map((book) => (
-                              <SelectItem
-                                key={book.id}
-                                value={book.id}
-                                className={styles.selectItem}
-                              >
-                                {book.name}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
+                          placeholder="Select book"
+                          searchPlaceholder="Search books…"
+                          triggerClassName={styles.selectTrigger}
+                          aria-label="Bible book"
+                        />
                         <p className={styles.dialogHint}>
                           {books.length > 0
                             ? `${books.length} books available in ${

--- a/components/NotesScreen.tsx
+++ b/components/NotesScreen.tsx
@@ -34,6 +34,7 @@ import {
   SelectValue,
 } from "./ui/select";
 import { Textarea } from "./ui/textarea";
+import { BookCombobox } from "@/components/bible/BookCombobox";
 import { LoadingScreen } from "@/components/LoadingScreen";
 import { buildReferenceLabel } from "@/lib/api/bible";
 import type { BibleBookSummary } from "@/types/bible";
@@ -523,30 +524,21 @@ export function NotesScreen({ onNavigate }: NotesScreenProps = {}) {
               <div className={`${styles.fieldGrid} ${styles.fieldGridTwoColumns}`}>
                 <div className={styles.fieldGroup}>
                   <span className={styles.fieldLabel}>Book</span>
-                  <Select
+                  <BookCombobox
+                    books={books}
                     value={createBookId ?? undefined}
+                    valueKey="id"
                     onValueChange={(value) => {
                       setCreateBookId(value);
                       setCreateChapter("1");
                       setCreateVerseStart("1");
                       setCreateVerseEnd("1");
                     }}
-                  >
-                    <SelectTrigger className={controls.control}>
-                      <SelectValue placeholder="Select book" />
-                    </SelectTrigger>
-                    <SelectContent className={`${styles.selectContent} z-[9999]`}>
-                      {books.map((book) => (
-                        <SelectItem
-                          key={book.id}
-                          value={book.id}
-                          className={styles.selectItem}
-                        >
-                          {book.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                    placeholder="Select book"
+                    searchPlaceholder="Search books…"
+                    triggerClassName={controls.control}
+                    aria-label="Bible book"
+                  />
                 </div>
                 <div className={styles.fieldGroup}>
                   <span className={styles.fieldLabel}>Chapter</span>

--- a/components/bible/BookCombobox.tsx
+++ b/components/bible/BookCombobox.tsx
@@ -25,6 +25,7 @@ export type BookComboboxProps = {
   disabled?: boolean;
   className?: string;
   triggerClassName?: string;
+  contentClassName?: string;
   id?: string;
   "aria-label"?: string;
 };
@@ -44,6 +45,7 @@ export function BookCombobox({
   disabled = false,
   className,
   triggerClassName,
+  contentClassName,
   id,
   "aria-label": ariaLabel = "Bible book",
 }: BookComboboxProps) {
@@ -83,6 +85,7 @@ export function BookCombobox({
       disabled={disabled}
       className={className}
       triggerClassName={triggerClassName}
+      contentClassName={contentClassName}
       aria-label={ariaLabel}
     />
   );

--- a/components/notes/AudioNotePanel.tsx
+++ b/components/notes/AudioNotePanel.tsx
@@ -14,14 +14,8 @@ import { Mic, RotateCcw, Square, Loader2 } from "lucide-react";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Textarea } from "../ui/textarea";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "../ui/select";
 
+import { BookCombobox } from "@/components/bible/BookCombobox";
 import { useSpeechRecognition } from "@/lib/hooks/useSpeechRecognition";
 import { parseReferenceFromText } from "@/lib/bible/parseReferenceFromText";
 import type { BibleBookSummary } from "@/types/bible";
@@ -450,21 +444,17 @@ export function AudioNotePanel({
               <label className={styles.fieldLabel} htmlFor="audio-note-book">
                 Book
               </label>
-              <Select
+              <BookCombobox
+                id="audio-note-book"
+                books={books}
                 value={selectedBookId ?? undefined}
+                valueKey="id"
                 onValueChange={(value) => setSelectedBookId(value)}
-              >
-                <SelectTrigger id="audio-note-book" className={controls.control}>
-                  <SelectValue placeholder="Select book" />
-                </SelectTrigger>
-                <SelectContent>
-                  {bookOptions.map((book) => (
-                    <SelectItem key={book.id} value={book.id}>
-                      {book.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                placeholder="Select book"
+                searchPlaceholder="Search books…"
+                triggerClassName={controls.control}
+                aria-label="Bible book"
+              />
             </div>
             <div className={styles.field}>
               <label className={styles.fieldLabel} htmlFor="audio-note-chapter">

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -158,7 +158,8 @@ export function Combobox({
           align="start"
           sideOffset={6}
           className={cn(
-            "w-[var(--radix-popover-trigger-width)] max-w-[min(100vw-1.5rem,28rem)] border-0 bg-transparent p-0 shadow-none",
+            // Above Modal content (z-70) so typeahead works inside dialogs.
+            "z-[80] w-[var(--radix-popover-trigger-width)] max-w-[min(100vw-1.5rem,28rem)] border-0 bg-transparent p-0 shadow-none",
             styles.content,
             contentClassName,
           )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Wires the existing `BookCombobox` typeahead into member-facing book inputs that were still plain Radix `Select`s (scroll-only).

### Changes
- **Bible reader** toolbar book picker → searchable `BookCombobox` (`valueKey="id"`), with title-style trigger CSS updates
- **Notes** create-reflection book field → `BookCombobox`
- **Memory** add-verse book field → `BookCombobox`
- **Audio note** confirm-reference book field → `BookCombobox`
- Raise Combobox popover z-index above Modal content so typeahead works in dialogs
- Expose optional `contentClassName` on `BookCombobox`

Matches aliases/abbreviations already supported by admin Pre-Read (e.g. `gen`, `1 cor`).

## Test plan
- [ ] Reader: open book picker, type `gen` / `john` / `1 cor`, select and confirm chapter resets to 1
- [ ] Notes → New reflection: book typeahead works inside the modal
- [ ] Memory → Add verse: book typeahead works inside the modal
- [ ] Audio note confirm step: book typeahead works
- [ ] Chapter/verse Selects still work as before
- [ ] `npm test` passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd470-093b-7fef-94dd-3e57d177793b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd470-093b-7fef-94dd-3e57d177793b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

